### PR TITLE
Prefer caret constraints over wildcards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
 	"name": "microsoft/microsoft-graph",
-	"version": "1.0.1",
 	"type": "library",
 	"description": "The Microsoft Graph SDK for PHP",
 	"homepage": "https://graph.microsoft.io/en-us/",

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,16 @@
 	],
 	"require": {
 		"php": "^5.6 || ^7.0",
-		"guzzlehttp/guzzle": "6.2.*"
+		"guzzlehttp/guzzle": "^6.2"
 	},
-	"require-dev": { "phpunit/phpunit": "5.5.*",
-					 "phpdocumentor/phpdocumentor": "2.9.*",
-					 "mikey179/vfsStream": "~1"
-				    },
+	"require-dev": {
+		"phpunit/phpunit": "^5.5",
+		"phpdocumentor/phpdocumentor": "^2.9",
+		"mikey179/vfsStream": "^1"
+	},
 	"autoload": {
 		"psr-4": { "Microsoft\\Graph\\": "src/",
-				   "Microsoft\\Graph\\Test\\": "tests/Functional/"
-			 	}
+			"Microsoft\\Graph\\Test\\": "tests/Functional/"
+	 	}
 	}
 }


### PR DESCRIPTION
Specifically in this case this library was stopping Guzzle 6.3 from being installed while Semver guarantees its compatibility. You should always use caret constraints unless there is a very good reason not to.

The other changes are simply layout.