### PR TITLE
Package version bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can install the PHP SDK with Composer.
 ```
 {
     "require": {
-        "microsoft/microsoft-graph": "1.0.*"
+        "microsoft/microsoft-graph": "^1.0.0"
     }
 }
 ```

--- a/THIRD PARTY NOTICES
+++ b/THIRD PARTY NOTICES
@@ -1,0 +1,19 @@
+This file is based on or incorporates material from the projects listed below (Third Party OSS). The original copyright notice and the license under which Microsoft received such Third Party OSS, are set forth below. Such licenses and notices are provided for informational purposes only. Microsoft licenses the Third Party OSS to you under the licensing terms for the Microsoft product or service. Microsoft 
+reserves all other rights not expressly granted under this agreement, whether by implication, estoppel or otherwise.  
+
+guzzlehttp guzzle - 6.3.0
+Copyright (c) 2011-2016 Michael Dowling, https://github.com/mtdowling <mtdowling@gmail.com>
+
+phpdocumentor - 2.9.0
+Copyright (c) 2010 Mike van Riel
+ 
+Provided for Informational Purposes Only 
+  
+MIT License  
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the Software), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:  
+ 
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. 
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF  
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"require-dev": { 
 		"phpunit/phpunit": "5.5.*",
 		"phpdocumentor/phpdocumentor": "2.9.*",
-		"mikey179/vfsStream": "~1"
+		"mikey179/vfsStream": "1.6.*"
 	},
 	"autoload": {
 		"psr-4": { 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
 	"name": "microsoft/microsoft-graph",
-	"version": "1.0.1",
 	"type": "library",
 	"description": "The Microsoft Graph SDK for PHP",
 	"homepage": "https://graph.microsoft.io/en-us/",
@@ -14,15 +13,17 @@
 	],
 	"require": {
 		"php": "^5.6 || ^7.0",
-		"guzzlehttp/guzzle": "6.2.*"
+		"guzzlehttp/guzzle": "6.3.*"
 	},
-	"require-dev": { "phpunit/phpunit": "5.5.*",
-					 "phpdocumentor/phpdocumentor": "2.9.*",
-					 "mikey179/vfsStream": "~1"
-				    },
+	"require-dev": { 
+		"phpunit/phpunit": "5.5.*",
+		"phpdocumentor/phpdocumentor": "2.9.*",
+		"mikey179/vfsStream": "~1"
+	},
 	"autoload": {
-		"psr-4": { "Microsoft\\Graph\\": "src/",
-				   "Microsoft\\Graph\\Test\\": "tests/Functional/"
-			 	}
+		"psr-4": { 
+			"Microsoft\\Graph\\": "src/",
+			"Microsoft\\Graph\\Test\\": "tests/Functional/"
+		}
 	}
 }


### PR DESCRIPTION
- Updated Guzzle to version 6.3, including advice from #22 
- Added Third Party Notices to repo

After registering new versions of our dependencies, we should start specifying accepted ranges. Currently, there is only one registered version, so it doesn't make sense to use a range.