### PR TITLE
Expand automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
     - composer self-update
 
 install:
-    - composer install --prefer-source --no-interaction --no-progress --no-suggest $COMPOSER_FLAGS
+    - composer update --prefer-source --no-interaction --no-progress --no-suggest $COMPOSER_FLAGS
 
 script:
     - vendor/bin/phpunit --exclude-group functional

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: php
 
-php:
-    - '5.6'
-    - '7.0'
-    - '7.1'
+matrix:
+    include:
+        - php: 5.6
+        - php: 7.0
+        - php: 7.1
+        - php: 5.6
+          env: COMPOSER_FLAGS="--prefer-lowest"
 
 before_install:
     - composer self-update
 
 install:
-    - composer install --prefer-source --no-interaction --dev
+    - composer install --prefer-source --no-interaction --no-progress --no-suggest $COMPOSER_FLAGS
 
 script:
     - vendor/bin/phpunit --exclude-group functional

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require-dev": { "phpunit/phpunit": "5.5.*",
 					 "phpdocumentor/phpdocumentor": "2.9.*",
-					 "mikey179/vfsStream": "~1"
+					 "mikey179/vfsStream": "^1.2"
 				    },
 	"autoload": {
 		"psr-4": { "Microsoft\\Graph\\": "src/",


### PR DESCRIPTION
- Include a test suite with lowest possible dependencies using lowest non-EOL PHP version
- Scrap `-dev` flag for `composer install` (it's default)
- Remove CI log clutter by hiding suggestions and progress indicators in Composer