### PR TITLE
Functional test bugfixes

### DIFF
--- a/tests/Functional/ExcelTest.php
+++ b/tests/Functional/ExcelTest.php
@@ -14,7 +14,7 @@ class ExcelTest extends TestCase
         $graphTestBase = new GraphTestBase();
         $this->_client = $graphTestBase->graphClient;
 
-        $this->_fileId = $this->createTestFile('_excelTestResource.xlsx');
+        $this->_fileId = $this->createTestFile('_excelTestResource'.rand().'.xlsx');
         $this->uploadTestFileContent($this->_fileId);
     }
 

--- a/tests/Functional/OnenoteTest.php
+++ b/tests/Functional/OnenoteTest.php
@@ -110,8 +110,8 @@ class OnenoteTest extends TestCase
         $end = "\r\n\r\n" .
                 "--" . $boundary . "--";
 
-        $imageStream = GuzzleHttp\Psr7\stream_for(fopen(".\\tests\\Functional\\Resources\\hamilton.jpg", "r"));
-        $docStream = GuzzleHttp\Psr7\stream_for(fopen(".\\tests\\Functional\\Resources\\document.pdf", "r"));
+        $imageStream = GuzzleHttp\Psr7\stream_for(fopen("./tests/Functional/Resources/hamilton.jpg", "r"));
+        $docStream = GuzzleHttp\Psr7\stream_for(fopen("./tests/Functional/Resources/document.pdf", "r"));
 
         $request = GuzzleHttp\Psr7\stream_for($html . $imageStream . $doc . $docStream . $end);
 

--- a/tests/Functional/OpenTypeTest.php
+++ b/tests/Functional/OpenTypeTest.php
@@ -37,6 +37,7 @@ class OpenTypeTest extends TestCase
     */
     public function testSchemaExtensions()
     {
+        $this->markTestSkipped();
         $extension = new Model\SchemaExtension();
         $extension->setId("schematest");
         $extension->setDescription("PHP Graph SDK test");


### PR DESCRIPTION
- Make a randomly named Excel file so tests can be run on multiple machines simultaneously
- Correct file path for OneNote image
- Skip schema extension test until we can lock down the demo tenant