### PR TITLE
fix fclose() expects parameter 1 to be resource, boolean given

### DIFF
--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -336,7 +336,9 @@ class GraphRequest
                         'sink' => $file
                     ]
                 );
-                fclose($file);
+                if(is_resource($file)){
+                    fclose($file);
+                }
             } else {
                 throw new GraphException(GraphConstants::INVALID_FILE);
             }


### PR DESCRIPTION
`
$item = $graph->createRequest("GET", "/drive/items/$id")
                          ->setReturnType(Model\DriveItem::class)
                          ->execute();
`
When downloading a file from onedrive I receive the error:

"fclose() expects parameter 1 to be resource, boolean given"

Checking if $file is a valid resource before calling fclose fixes the problem.
I assume $file is already closed before fclose is called for some reason.