### PR TITLE
include @odata.context and @odata.nextLink should they exist.

### DIFF
--- a/src/Http/GraphResponse.php
+++ b/src/Http/GraphResponse.php
@@ -155,6 +155,10 @@ class GraphResponse
             if (array_key_exists('@odata.nextLink', $result)) {
                 $objArray['@odata.nextLink'] = $result['@odata.nextLink'];
             }
+            
+            if (array_key_exists('@odata.count', $result)) {
+                $objArray['@odata.count'] = $result['@odata.count'];
+            }
 
             //Check that this is an object array instead of a value called "value"
             if ($values && is_array($values)) {

--- a/src/Http/GraphResponse.php
+++ b/src/Http/GraphResponse.php
@@ -147,6 +147,14 @@ class GraphResponse
         if (array_key_exists('value', $result)) {
             $objArray = array();
             $values = $result['value'];
+            
+            if (array_key_exists('@odata.context', $result)) {
+                $objArray['@odata.context'] = $result['@odata.context'];
+            }
+
+            if (array_key_exists('@odata.nextLink', $result)) {
+                $objArray['@odata.nextLink'] = $result['@odata.nextLink'];
+            }
 
             //Check that this is an object array instead of a value called "value"
             if ($values && is_array($values)) {


### PR DESCRIPTION
@odata.context and @odata.nextLink currently are excluded from the response that is returned only the result array is being returned, so no next link attribute is being returned.

This solves issue #60