### PR TITLE
Remove requirement for file to exist before creating it

### DIFF
--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -321,11 +321,17 @@ class GraphRequest
     */
     public function download($path, $client = null)
     {
+        //Add custom error handler to catch file I/O warnings
+        set_error_handler(function() {});
+
         if (is_null($client)) {
             $client = $this->createGuzzleClient();
         }
         try {
             $file = fopen($path, 'w');
+            if (!$file) {
+                throw new GraphException(GraphConstants::INVALID_FILE);
+            }
 
             $client->request(
                 $this->requestType, 
@@ -342,6 +348,8 @@ class GraphRequest
         } catch(GraphException $e) {
             throw new GraphException(GraphConstants::INVALID_FILE);
         }
+        //Restore default error handler
+        restore_error_handler();
         return null;
     }
 

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -321,9 +321,6 @@ class GraphRequest
     */
     public function download($path, $client = null)
     {
-        //Add custom error handler to catch file I/O warnings
-        set_error_handler(function() {});
-
         if (is_null($client)) {
             $client = $this->createGuzzleClient();
         }
@@ -348,8 +345,7 @@ class GraphRequest
         } catch(GraphException $e) {
             throw new GraphException(GraphConstants::INVALID_FILE);
         }
-        //Restore default error handler
-        restore_error_handler();
+
         return null;
     }
 

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -325,22 +325,18 @@ class GraphRequest
             $client = $this->createGuzzleClient();
         }
         try {
-            if (file_exists($path) && is_writeable($path)) {
-                $file = fopen($path, 'w');
+            $file = fopen($path, 'w');
 
-                $client->request(
-                    $this->requestType, 
-                    $this->_getRequestUrl(), 
-                    [
-                        'body' => $this->requestBody,
-                        'sink' => $file
-                    ]
-                );
-                if(is_resource($file)){
-                    fclose($file);
-                }
-            } else {
-                throw new GraphException(GraphConstants::INVALID_FILE);
+            $client->request(
+                $this->requestType, 
+                $this->_getRequestUrl(), 
+                [
+                    'body' => $this->requestBody,
+                    'sink' => $file
+                ]
+            );
+            if(is_resource($file)){
+                fclose($file);
             }
             
         } catch(GraphException $e) {

--- a/tests/Functional/OnedriveTest.php
+++ b/tests/Functional/OnedriveTest.php
@@ -56,6 +56,33 @@ class OnedriveTest extends TestCase
     /**
     * @group functional
     */
+    public function testDownloadFile()
+    {
+        $driveItems = $this->_client->createRequest("GET", "/me/drive/root/children")
+                                    ->setReturnType(Model\DriveItem::class)
+                                    ->execute();
+        foreach ($driveItems as $item)
+        {
+            //Find the first non-folder resource to download
+            if ($item->getFile())
+            {
+                $itemId = $item->getId();
+                $itemName = $item->getName();
+                $itemName = str_replace(" ", "_", $itemName);
+
+                $driveItemContent = $this->_client->createRequest("GET", "/me/drive/items/$itemId/content")
+                                                  ->download("D:\\".$itemName);
+                $this->assertTrue(file_exists("D:\\".$itemName));
+                unlink("D:\\".$itemName);
+                break;
+            }
+        }
+    }
+
+
+    /**
+    * @group functional
+    */
     public function testGetSetPermissions()
     {
     	$driveItems = $this->_client->createRequest("GET", "/me/drive/root/children")

--- a/tests/Http/StreamTest.php
+++ b/tests/Http/StreamTest.php
@@ -70,13 +70,18 @@ class StreamTest extends TestCase
 
     public function testInvalidDownload()
     {
-        $this->expectException(Microsoft\Graph\Exception\GraphException::class);
+        set_error_handler(function() {});
+        try {
+            $this->expectException(Microsoft\Graph\Exception\GraphException::class);
 
-        $file = new VfsStreamFile('foo.txt', 0000);
-        $this->root->addChild($file);
+            $file = new VfsStreamFile('foo.txt', 0000);
+            $this->root->addChild($file);
 
-        $request = new GraphRequest("GET", "/me", "token", "url", "/v1.0");
-        $request->download($file->url(), $this->client);
+            $request = new GraphRequest("GET", "/me", "token", "url", "/v1.0");
+            $request->download($file->url(), $this->client);
+        } finally {
+            restore_error_handler();
+        } 
     }
 
     public function testSetReturnStream()


### PR DESCRIPTION
Fixes a bug where users cannot download files from Graph. Added a functional test to check redirect behavior mentioned in [SO post](https://stackoverflow.com/questions/46959384/not-possible-to-download-file-using-phps-microsoft-graph-sdk)