### PR TITLE
Faulty type-check of DateTime-objects corrected

### DIFF
--- a/src/Model/AssignedPlan.php
+++ b/src/Model/AssignedPlan.php
@@ -35,7 +35,7 @@ class AssignedPlan extends Entity
     public function getAssignedDateTime()
     {
         if (array_key_exists("assignedDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["assignedDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["assignedDateTime"], \DateTime::class)) {
                 return $this->_propDict["assignedDateTime"];
             } else {
                 $this->_propDict["assignedDateTime"] = new \DateTime($this->_propDict["assignedDateTime"]);

--- a/src/Model/DeviceActionResult.php
+++ b/src/Model/DeviceActionResult.php
@@ -96,7 +96,7 @@ class DeviceActionResult extends Entity
     public function getStartDateTime()
     {
         if (array_key_exists("startDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["startDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["startDateTime"], \DateTime::class)) {
                 return $this->_propDict["startDateTime"];
             } else {
                 $this->_propDict["startDateTime"] = new \DateTime($this->_propDict["startDateTime"]);
@@ -129,7 +129,7 @@ class DeviceActionResult extends Entity
     public function getLastUpdatedDateTime()
     {
         if (array_key_exists("lastUpdatedDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["lastUpdatedDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["lastUpdatedDateTime"], \DateTime::class)) {
                 return $this->_propDict["lastUpdatedDateTime"];
             } else {
                 $this->_propDict["lastUpdatedDateTime"] = new \DateTime($this->_propDict["lastUpdatedDateTime"]);

--- a/src/Model/DeviceGeoLocation.php
+++ b/src/Model/DeviceGeoLocation.php
@@ -35,7 +35,7 @@ class DeviceGeoLocation extends Entity
     public function getLastCollectedDateTime()
     {
         if (array_key_exists("lastCollectedDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["lastCollectedDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["lastCollectedDateTime"], \DateTime::class)) {
                 return $this->_propDict["lastCollectedDateTime"];
             } else {
                 $this->_propDict["lastCollectedDateTime"] = new \DateTime($this->_propDict["lastCollectedDateTime"]);

--- a/src/Model/DeviceHealthAttestationState.php
+++ b/src/Model/DeviceHealthAttestationState.php
@@ -147,7 +147,7 @@ class DeviceHealthAttestationState extends Entity
     public function getIssuedDateTime()
     {
         if (array_key_exists("issuedDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["issuedDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["issuedDateTime"], \DateTime::class)) {
                 return $this->_propDict["issuedDateTime"];
             } else {
                 $this->_propDict["issuedDateTime"] = new \DateTime($this->_propDict["issuedDateTime"]);

--- a/src/Model/DomainState.php
+++ b/src/Model/DomainState.php
@@ -91,7 +91,7 @@ class DomainState extends Entity
     public function getLastActionDateTime()
     {
         if (array_key_exists("lastActionDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["lastActionDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["lastActionDateTime"], \DateTime::class)) {
                 return $this->_propDict["lastActionDateTime"];
             } else {
                 $this->_propDict["lastActionDateTime"] = new \DateTime($this->_propDict["lastActionDateTime"]);

--- a/src/Model/EducationStudent.php
+++ b/src/Model/EducationStudent.php
@@ -91,7 +91,7 @@ class EducationStudent extends Entity
     public function getBirthDate()
     {
         if (array_key_exists("birthDate", $this->_propDict)) {
-            if (is_a($this->_propDict["birthDate"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["birthDate"], \DateTime::class)) {
                 return $this->_propDict["birthDate"];
             } else {
                 $this->_propDict["birthDate"] = new \DateTime($this->_propDict["birthDate"]);

--- a/src/Model/EducationTerm.php
+++ b/src/Model/EducationTerm.php
@@ -63,7 +63,7 @@ class EducationTerm extends Entity
     public function getStartDate()
     {
         if (array_key_exists("startDate", $this->_propDict)) {
-            if (is_a($this->_propDict["startDate"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["startDate"], \DateTime::class)) {
                 return $this->_propDict["startDate"];
             } else {
                 $this->_propDict["startDate"] = new \DateTime($this->_propDict["startDate"]);
@@ -96,7 +96,7 @@ class EducationTerm extends Entity
     public function getEndDate()
     {
         if (array_key_exists("endDate", $this->_propDict)) {
-            if (is_a($this->_propDict["endDate"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["endDate"], \DateTime::class)) {
                 return $this->_propDict["endDate"];
             } else {
                 $this->_propDict["endDate"] = new \DateTime($this->_propDict["endDate"]);

--- a/src/Model/FileSystemInfo.php
+++ b/src/Model/FileSystemInfo.php
@@ -35,7 +35,7 @@ class FileSystemInfo extends Entity
     public function getCreatedDateTime()
     {
         if (array_key_exists("createdDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["createdDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["createdDateTime"], \DateTime::class)) {
                 return $this->_propDict["createdDateTime"];
             } else {
                 $this->_propDict["createdDateTime"] = new \DateTime($this->_propDict["createdDateTime"]);
@@ -68,7 +68,7 @@ class FileSystemInfo extends Entity
     public function getLastAccessedDateTime()
     {
         if (array_key_exists("lastAccessedDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["lastAccessedDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["lastAccessedDateTime"], \DateTime::class)) {
                 return $this->_propDict["lastAccessedDateTime"];
             } else {
                 $this->_propDict["lastAccessedDateTime"] = new \DateTime($this->_propDict["lastAccessedDateTime"]);
@@ -101,7 +101,7 @@ class FileSystemInfo extends Entity
     public function getLastModifiedDateTime()
     {
         if (array_key_exists("lastModifiedDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["lastModifiedDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["lastModifiedDateTime"], \DateTime::class)) {
                 return $this->_propDict["lastModifiedDateTime"];
             } else {
                 $this->_propDict["lastModifiedDateTime"] = new \DateTime($this->_propDict["lastModifiedDateTime"]);

--- a/src/Model/OmaSettingDateTime.php
+++ b/src/Model/OmaSettingDateTime.php
@@ -35,7 +35,7 @@ class OmaSettingDateTime extends OmaSetting
     public function getValue()
     {
         if (array_key_exists("value", $this->_propDict)) {
-            if (is_a($this->_propDict["value"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["value"], \DateTime::class)) {
                 return $this->_propDict["value"];
             } else {
                 $this->_propDict["value"] = new \DateTime($this->_propDict["value"]);

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -231,7 +231,7 @@ class Photo extends Entity
     public function getTakenDateTime()
     {
         if (array_key_exists("takenDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["takenDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["takenDateTime"], \DateTime::class)) {
                 return $this->_propDict["takenDateTime"];
             } else {
                 $this->_propDict["takenDateTime"] = new \DateTime($this->_propDict["takenDateTime"]);

--- a/src/Model/PlannerAssignment.php
+++ b/src/Model/PlannerAssignment.php
@@ -68,7 +68,7 @@ class PlannerAssignment extends Entity
     public function getAssignedDateTime()
     {
         if (array_key_exists("assignedDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["assignedDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["assignedDateTime"], \DateTime::class)) {
                 return $this->_propDict["assignedDateTime"];
             } else {
                 $this->_propDict["assignedDateTime"] = new \DateTime($this->_propDict["assignedDateTime"]);

--- a/src/Model/PlannerChecklistItem.php
+++ b/src/Model/PlannerChecklistItem.php
@@ -152,7 +152,7 @@ class PlannerChecklistItem extends Entity
     public function getLastModifiedDateTime()
     {
         if (array_key_exists("lastModifiedDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["lastModifiedDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["lastModifiedDateTime"], \DateTime::class)) {
                 return $this->_propDict["lastModifiedDateTime"];
             } else {
                 $this->_propDict["lastModifiedDateTime"] = new \DateTime($this->_propDict["lastModifiedDateTime"]);

--- a/src/Model/PlannerExternalReference.php
+++ b/src/Model/PlannerExternalReference.php
@@ -152,7 +152,7 @@ class PlannerExternalReference extends Entity
     public function getLastModifiedDateTime()
     {
         if (array_key_exists("lastModifiedDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["lastModifiedDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["lastModifiedDateTime"], \DateTime::class)) {
                 return $this->_propDict["lastModifiedDateTime"];
             } else {
                 $this->_propDict["lastModifiedDateTime"] = new \DateTime($this->_propDict["lastModifiedDateTime"]);

--- a/src/Model/RecentNotebook.php
+++ b/src/Model/RecentNotebook.php
@@ -61,7 +61,7 @@ class RecentNotebook extends Entity
     public function getLastAccessedTime()
     {
         if (array_key_exists("lastAccessedTime", $this->_propDict)) {
-            if (is_a($this->_propDict["lastAccessedTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["lastAccessedTime"], \DateTime::class)) {
                 return $this->_propDict["lastAccessedTime"];
             } else {
                 $this->_propDict["lastAccessedTime"] = new \DateTime($this->_propDict["lastAccessedTime"]);

--- a/src/Model/RecurrenceRange.php
+++ b/src/Model/RecurrenceRange.php
@@ -68,7 +68,7 @@ class RecurrenceRange extends Entity
     public function getStartDate()
     {
         if (array_key_exists("startDate", $this->_propDict)) {
-            if (is_a($this->_propDict["startDate"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["startDate"], \DateTime::class)) {
                 return $this->_propDict["startDate"];
             } else {
                 $this->_propDict["startDate"] = new \DateTime($this->_propDict["startDate"]);
@@ -101,7 +101,7 @@ class RecurrenceRange extends Entity
     public function getEndDate()
     {
         if (array_key_exists("endDate", $this->_propDict)) {
-            if (is_a($this->_propDict["endDate"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["endDate"], \DateTime::class)) {
                 return $this->_propDict["endDate"];
             } else {
                 $this->_propDict["endDate"] = new \DateTime($this->_propDict["endDate"]);

--- a/src/Model/RemoteItem.php
+++ b/src/Model/RemoteItem.php
@@ -68,7 +68,7 @@ class RemoteItem extends Entity
     public function getCreatedDateTime()
     {
         if (array_key_exists("createdDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["createdDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["createdDateTime"], \DateTime::class)) {
                 return $this->_propDict["createdDateTime"];
             } else {
                 $this->_propDict["createdDateTime"] = new \DateTime($this->_propDict["createdDateTime"]);
@@ -261,7 +261,7 @@ class RemoteItem extends Entity
     public function getLastModifiedDateTime()
     {
         if (array_key_exists("lastModifiedDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["lastModifiedDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["lastModifiedDateTime"], \DateTime::class)) {
                 return $this->_propDict["lastModifiedDateTime"];
             } else {
                 $this->_propDict["lastModifiedDateTime"] = new \DateTime($this->_propDict["lastModifiedDateTime"]);

--- a/src/Model/ResponseStatus.php
+++ b/src/Model/ResponseStatus.php
@@ -68,7 +68,7 @@ class ResponseStatus extends Entity
     public function getTime()
     {
         if (array_key_exists("time", $this->_propDict)) {
-            if (is_a($this->_propDict["time"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["time"], \DateTime::class)) {
                 return $this->_propDict["time"];
             } else {
                 $this->_propDict["time"] = new \DateTime($this->_propDict["time"]);

--- a/src/Model/Shared.php
+++ b/src/Model/Shared.php
@@ -129,7 +129,7 @@ class Shared extends Entity
     public function getSharedDateTime()
     {
         if (array_key_exists("sharedDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["sharedDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["sharedDateTime"], \DateTime::class)) {
                 return $this->_propDict["sharedDateTime"];
             } else {
                 $this->_propDict["sharedDateTime"] = new \DateTime($this->_propDict["sharedDateTime"]);

--- a/src/Model/UploadSession.php
+++ b/src/Model/UploadSession.php
@@ -35,7 +35,7 @@ class UploadSession extends Entity
     public function getExpirationDateTime()
     {
         if (array_key_exists("expirationDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["expirationDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["expirationDateTime"], \DateTime::class)) {
                 return $this->_propDict["expirationDateTime"];
             } else {
                 $this->_propDict["expirationDateTime"] = new \DateTime($this->_propDict["expirationDateTime"]);

--- a/src/Model/WindowsInformationProtectionDataRecoveryCertificate.php
+++ b/src/Model/WindowsInformationProtectionDataRecoveryCertificate.php
@@ -91,7 +91,7 @@ class WindowsInformationProtectionDataRecoveryCertificate extends Entity
     public function getExpirationDateTime()
     {
         if (array_key_exists("expirationDateTime", $this->_propDict)) {
-            if (is_a($this->_propDict["expirationDateTime"], "Microsoft\Graph\Model\\DateTime")) {
+            if (is_a($this->_propDict["expirationDateTime"], \DateTime::class)) {
                 return $this->_propDict["expirationDateTime"];
             } else {
                 $this->_propDict["expirationDateTime"] = new \DateTime($this->_propDict["expirationDateTime"]);

--- a/tests/Model/RecurrenceRangeTest.php
+++ b/tests/Model/RecurrenceRangeTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Microsoft\Graph\Model\RecurrenceRange;
+use PHPUnit\Framework\TestCase;
+
+class RecurrenceRangeTest extends TestCase
+{
+
+    public function testGetStartDate()
+    {
+        $recurrenceRange = new RecurrenceRange(['startDate'=>'2017-01-01']);
+
+        $this->assertInstanceOf(\DateTime::class,$recurrenceRange->getStartDate());
+        // Test that is still a DateTime-object after requesting it twice
+        $this->assertInstanceOf(\DateTime::class,$recurrenceRange->getStartDate());
+    }
+}


### PR DESCRIPTION
When requesting a property of type DateTime for a second time,
you would not receive the correct DateTime-object.

This was caused by checking if we allready converted the property
by comparing the type of the property.  However it was compared
against `Microsoft\Graph\Model\DateTime` instead of `DateTime`.

I also included a unit test for one affected type to show what went wrong.