### PR TITLE
Be able to change the accessToken of a request

### DIFF
--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -134,6 +134,20 @@ class GraphRequest
     }
 
     /**
+    * Sets a new accessToken
+    *
+    * @param string $accessToken A valid access token to validate the Graph call
+    *
+    * @return GraphRequest object
+    */
+    public function setAccessToken($accessToken)
+    {
+        $this->accessToken = $accessToken;
+        $this->headers['Authorization'] = 'Bearer ' . $this->accessToken;
+        return $this;
+    }
+
+    /**
     * Sets the return type of the response object
     *
     * @param mixed $returnClass The object class to use

--- a/tests/Functional/DeltaQueryTest.php
+++ b/tests/Functional/DeltaQueryTest.php
@@ -6,11 +6,12 @@ use Microsoft\Graph\Model;
 class DeltaQueryTest extends TestCase
 {
     private $_client;
+    private $graphTestBase;
 
     protected function setUp()
     {
-        $graphTestBase = new GraphTestBase();
-        $this->_client = $graphTestBase->graphClient;
+        $this->graphTestBase = new GraphTestBase();
+        $this->_client = $this->graphTestBase->graphClient;
     }
 
     /**
@@ -45,5 +46,30 @@ class DeltaQueryTest extends TestCase
 
         // Count is likely 0 but collection should not be null
         $this->assertNotNull($groups);
+    }
+
+    /**
+    * @group functional
+    */
+    public function testSetAccessToken()
+    {
+        $this->_client->setApiVersion("beta");
+        $deltaPageRequest = $this->_client->createCollectionRequest("GET", "/groups/delta")
+            ->setReturnType(Model\Group::class);
+
+        // Test if we can change the accessToken
+        while (!$deltaPageRequest->isEnd()) {
+            // Store authentication-header
+            $oldAuthenticationHeader = $deltaPageRequest->getHeaders()['Authorization'];
+            // Set a new delta-token
+            $deltaPageRequest->setAccessToken($this->graphTestBase->getAccessToken());
+            // Get the new authentication-header
+            $newAuthenticationHeader = $deltaPageRequest->getHeaders()['Authorization'];
+            // Do the actual request
+            $groups = $deltaPageRequest->getPage();
+
+            $this->assertNotSame($oldAuthenticationHeader,$newAuthenticationHeader);
+            $this->assertNotNull($groups);
+        }
     }
 }

--- a/tests/Functional/GraphTestBase.php
+++ b/tests/Functional/GraphTestBase.php
@@ -6,53 +6,56 @@ include_once("TestConstants.php");
 
 class GraphTestBase
 {
-	private $clientId;
-	private $username;
-	private $password;
-	private $contentType = "application/x-www-form-urlencoded";
-	private $grantType = "password";
-	private $endpoint = "https://login.microsoftonline.com/common/oauth2/token";
-	private $resource = "https%3A%2F%2Fgraph.microsoft.com%2F";
-	private $accessToken;
-	public $graphClient;
+    private $clientId;
+    private $clientSecret;
+    private $username;
+    private $password;
+    private $contentType = "application/x-www-form-urlencoded";
+    private $grantType = "password";
+    private $endpoint = "https://login.microsoftonline.com/common/oauth2/token";
+    private $resource = "https%3A%2F%2Fgraph.microsoft.com%2F";
+    public $graphClient;
 
     public function __construct()
     {
-        $this->clientId = CLIENT_ID;
-        $this->username = USERNAME;
-        $this->password = PASSWORD;
+        $this->clientId     = CLIENT_ID;
+        $this->clientSecret = CLIENT_SECRET;
+        $this->username     = USERNAME;
+        $this->password     = PASSWORD;
 
         $this->getAuthenticatedClient();
     }
 
     public function getAuthenticatedClient()
     {
-    	if ($this->graphClient == null) 
-    	{
-    		$this->graphClient = new Graph();
-    		$this->graphClient->setAccessToken($this->getAccessToken());
-    	}
+        if ($this->graphClient == null) 
+        {
+            $this->graphClient = new Graph();
+            $this->graphClient->setAccessToken($this->getAccessToken());
+        }
     }
 
-    private function getAccessToken()
+    public function getAccessToken()
     {
-    	$body = "grant_type=".$this->grantType.
-    					 "&resource=".$this->resource.
-    					 "&client_id=".$this->clientId.
-    					 "&username=".$this->username.
-    					 "&password=".$this->password;
-    	$ch = curl_init();
-    	curl_setopt($ch, CURLOPT_URL, $this->endpoint);
-    	curl_setopt($ch, CURLOPT_POST, 1);
-    	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    	curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
-		curl_setopt($ch, CURLOPT_FAILONERROR, 0);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, array($this->contentType, 'Content-Length: ' . strlen($body)));
+        $body = "grant_type=".$this->grantType
+                ."&resource=".$this->resource
+                ."&client_id=".$this->clientId
+                ."&client_secret=".$this->clientSecret
+                ."&username=".$this->username
+                ."&password=".$this->password;
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $this->endpoint);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+        curl_setopt($ch, CURLOPT_FAILONERROR, 0);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array($this->contentType, 'Content-Length: ' . strlen($body)));
 
-		$result = curl_exec ($ch);
-		$token = json_decode($result, true)['access_token'];
-		curl_close($ch);
+        $result = curl_exec ($ch);
+        $token = json_decode($result, true)['access_token'];
+        curl_close($ch);
 
-		return $token;
+        return $token;
     }
+
 }

--- a/tests/Functional/TestConstants.php
+++ b/tests/Functional/TestConstants.php
@@ -12,6 +12,7 @@ namespace Microsoft\Graph\Test;
 * possible.
 */
 define("CLIENT_ID", getenv("client_id"));
+define("CLIENT_SECRET", getenv("client_secret"));
 define ("USERNAME", getenv("test_username"));
 define("PASSWORD", getenv("test_password"));
 


### PR DESCRIPTION
I added the method `setAccessToken()` to the `GraphRequest`-class, as suggested in #68. 

I also added a functional unittest for it that passes.  I did however have to adjust the method to fetch accessTokens.

Finally I replaced all tabs by spaces in those test-files.