### PR TITLE
Reapply #79 without clientSecret

### DIFF
--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -134,6 +134,20 @@ class GraphRequest
     }
 
     /**
+    * Sets a new accessToken
+    *
+    * @param string $accessToken A valid access token to validate the Graph call
+    *
+    * @return GraphRequest object
+    */
+    public function setAccessToken($accessToken)
+    {
+        $this->accessToken = $accessToken;
+        $this->headers['Authorization'] = 'Bearer ' . $this->accessToken;
+        return $this;
+    }
+
+    /**
     * Sets the return type of the response object
     *
     * @param mixed $returnClass The object class to use

--- a/tests/Functional/DeltaQueryTest.php
+++ b/tests/Functional/DeltaQueryTest.php
@@ -6,11 +6,12 @@ use Microsoft\Graph\Model;
 class DeltaQueryTest extends TestCase
 {
     private $_client;
+    private $graphTestBase;
 
     protected function setUp()
     {
-        $graphTestBase = new GraphTestBase();
-        $this->_client = $graphTestBase->graphClient;
+        $this->graphTestBase = new GraphTestBase();
+        $this->_client = $this->graphTestBase->graphClient;
     }
 
     /**
@@ -45,5 +46,30 @@ class DeltaQueryTest extends TestCase
 
         // Count is likely 0 but collection should not be null
         $this->assertNotNull($groups);
+    }
+
+    /**
+    * @group functional
+    */
+    public function testSetAccessToken()
+    {
+        $this->_client->setApiVersion("beta");
+        $deltaPageRequest = $this->_client->createCollectionRequest("GET", "/groups/delta")
+            ->setReturnType(Model\Group::class);
+
+        // Test if we can change the accessToken
+        while (!$deltaPageRequest->isEnd()) {
+            // Store authentication-header
+            $oldAuthenticationHeader = $deltaPageRequest->getHeaders()['Authorization'];
+            // Set a new delta-token
+            $deltaPageRequest->setAccessToken($this->graphTestBase->getAccessToken());
+            // Get the new authentication-header
+            $newAuthenticationHeader = $deltaPageRequest->getHeaders()['Authorization'];
+            // Do the actual request
+            $groups = $deltaPageRequest->getPage();
+
+            $this->assertNotSame($oldAuthenticationHeader,$newAuthenticationHeader);
+            $this->assertNotNull($groups);
+        }
     }
 }

--- a/tests/Functional/GraphTestBase.php
+++ b/tests/Functional/GraphTestBase.php
@@ -7,7 +7,6 @@ include_once("TestConstants.php");
 class GraphTestBase
 {
     private $clientId;
-    private $clientSecret;
     private $username;
     private $password;
     private $contentType = "application/x-www-form-urlencoded";

--- a/tests/Functional/GraphTestBase.php
+++ b/tests/Functional/GraphTestBase.php
@@ -6,53 +6,54 @@ include_once("TestConstants.php");
 
 class GraphTestBase
 {
-	private $clientId;
-	private $username;
-	private $password;
-	private $contentType = "application/x-www-form-urlencoded";
-	private $grantType = "password";
-	private $endpoint = "https://login.microsoftonline.com/common/oauth2/token";
-	private $resource = "https%3A%2F%2Fgraph.microsoft.com%2F";
-	private $accessToken;
-	public $graphClient;
+    private $clientId;
+    private $clientSecret;
+    private $username;
+    private $password;
+    private $contentType = "application/x-www-form-urlencoded";
+    private $grantType = "password";
+    private $endpoint = "https://login.microsoftonline.com/common/oauth2/token";
+    private $resource = "https%3A%2F%2Fgraph.microsoft.com%2F";
+    public $graphClient;
 
     public function __construct()
     {
-        $this->clientId = CLIENT_ID;
-        $this->username = USERNAME;
-        $this->password = PASSWORD;
+        $this->clientId     = CLIENT_ID;
+        $this->username     = USERNAME;
+        $this->password     = PASSWORD;
 
         $this->getAuthenticatedClient();
     }
 
     public function getAuthenticatedClient()
     {
-    	if ($this->graphClient == null) 
-    	{
-    		$this->graphClient = new Graph();
-    		$this->graphClient->setAccessToken($this->getAccessToken());
-    	}
+        if ($this->graphClient == null) 
+        {
+            $this->graphClient = new Graph();
+            $this->graphClient->setAccessToken($this->getAccessToken());
+        }
     }
 
-    private function getAccessToken()
+    public function getAccessToken()
     {
-    	$body = "grant_type=".$this->grantType.
-    					 "&resource=".$this->resource.
-    					 "&client_id=".$this->clientId.
-    					 "&username=".$this->username.
-    					 "&password=".$this->password;
-    	$ch = curl_init();
-    	curl_setopt($ch, CURLOPT_URL, $this->endpoint);
-    	curl_setopt($ch, CURLOPT_POST, 1);
-    	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    	curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
-		curl_setopt($ch, CURLOPT_FAILONERROR, 0);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, array($this->contentType, 'Content-Length: ' . strlen($body)));
+        $body = "grant_type=".$this->grantType
+                ."&resource=".$this->resource
+                ."&client_id=".$this->clientId
+                ."&username=".$this->username
+                ."&password=".$this->password;
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $this->endpoint);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+        curl_setopt($ch, CURLOPT_FAILONERROR, 0);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array($this->contentType, 'Content-Length: ' . strlen($body)));
 
-		$result = curl_exec ($ch);
-		$token = json_decode($result, true)['access_token'];
-		curl_close($ch);
+        $result = curl_exec ($ch);
+        $token = json_decode($result, true)['access_token'];
+        curl_close($ch);
 
-		return $token;
+        return $token;
     }
+
 }


### PR DESCRIPTION
@Zombaya, it looks like the accessToken updates were likely due to registering an app as a web app instead of a native app. While you can use a clientSecret to obtain an access token, it is not supported (see @psignoret's [comment](https://github.com/microsoftgraph/msgraph-sdk-php/pull/80)) in the revert.