### PR TITLE
Remove incorrect URL validation (fixes #85)

### DIFF
--- a/src/Core/GraphConstants.php
+++ b/src/Core/GraphConstants.php
@@ -24,7 +24,7 @@ final class GraphConstants
     const REST_ENDPOINT = "https://graph.microsoft.com/";
 
     // Define HTTP request constants
-    const SDK_VERSION = "1.3.0";
+    const SDK_VERSION = "1.3.1";
 
     // Define error constants
     const MAX_PAGE_SIZE = 999;

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -415,10 +415,6 @@ class GraphRequest
     */
     private function _getRequestUrl()
     {
-        //Send request with opaque URL
-        if (stripos($this->endpoint, "http") !== FALSE) {
-            return $this->endpoint;
-        }
         return $this->apiVersion . $this->endpoint;
     }
 


### PR DESCRIPTION
If enough deltalinks are called, this check will eventually fail as a case insensitive 'http' will appear in the string. We should be doing this check in the cstor.

Most of the tests passed. The ones that failed are expected.