### PR TITLE
Test if endpoint starts with http (fixes #91)

### DIFF
--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -415,6 +415,11 @@ class GraphRequest
     */
     private function _getRequestUrl()
     {
+        //Send request with opaque URL
+        if (stripos($this->endpoint, "http") === 0) {
+            return $this->endpoint;
+        }
+
         return $this->apiVersion . $this->endpoint;
     }
 


### PR DESCRIPTION
In relation to issue #91, I suggest this patch.  This should not create a regression for issue #85.