### PR TITLE
 Always use the proxyPort when provided and add missing docbloc

### DIFF
--- a/src/Http/GraphCollectionRequest.php
+++ b/src/Http/GraphCollectionRequest.php
@@ -77,6 +77,7 @@ class GraphCollectionRequest extends GraphRequest
     * @param string $baseUrl     The base URL of the request
     * @param string $apiVersion  The version of the API to call
     * @param string $proxyPort   The url where to proxy through
+    * @throws GraphException when no access token is provided
     */
     public function __construct($requestType, $endpoint, $accessToken, $baseUrl, $apiVersion, $proxyPort = null)
     {

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -245,7 +245,7 @@ class GraphRequest
     public function execute($client = null)
     {
         if (is_null($client)) {
-            $client = $this->createGuzzleClient($this->proxyPort);
+            $client = $this->createGuzzleClient();
         }
 
         $result = $client->request(
@@ -286,7 +286,7 @@ class GraphRequest
     public function executeAsync($client = null)
     {
         if (is_null($client)) {
-            $client = $this->createGuzzleClient($this->proxyPort);
+            $client = $this->createGuzzleClient();
         }
 
         $promise = $client->requestAsync(
@@ -444,21 +444,21 @@ class GraphRequest
     * client is not reused. This allows the user
     * to set and change headers on a per-request
     * basis
-    * 
-    * @param string $proxyPort The port to forward
-    * requests through. If null, a proxy is not used
+    *
+    * If a proxyPort was passed in the constructor, all
+    * requests will be forwared through this proxy.
     *
     * @return \GuzzleHttp\Client The new client
     */
-    protected function createGuzzleClient($proxyPort = null)
+    protected function createGuzzleClient()
     { 
         $clientSettings = [
             'base_uri' => $this->baseUrl,
             'headers' => $this->headers
         ];
-        if ($proxyPort != null) {
+        if ($this->proxyPort !== null) {
             $clientSettings['verify'] = false;
-            $clientSettings['proxy'] = $proxyPort;
+            $clientSettings['proxy'] = $this->proxyPort;
         } 
         $client = new Client($clientSettings);
         


### PR DESCRIPTION
The provided proxyPort would not be used when calling the method `upload()` and `download()` of the class `GraphRequest`.  This resulted in missing  requests when trying to debug uploads and downloads to onedrive.

Also fixed a missing docbloc entry in GraphColllectionRequest.