### PR TITLE
Return empty array on empty collection request response

### DIFF
--- a/src/Http/GraphResponse.php
+++ b/src/Http/GraphResponse.php
@@ -153,9 +153,8 @@ class GraphResponse
                 foreach ($values as $obj) {
                     $objArray[] = new $class($obj);
                 }
-            } else {
-                return new $class($result);
             }
+            
             return $objArray;
         } else {
             return new $class($result);

--- a/tests/Http/GraphResponseTest.php
+++ b/tests/Http/GraphResponseTest.php
@@ -131,6 +131,6 @@ class GraphResponseTest extends TestCase
         $this->request->execute($this->client);
         $response = $this->request->setReturnType(Model\User::class)->execute($this->client);
 
-        $this->assertInstanceOf(Model\User::class, $response);
+        $this->assertContainsOnlyInstancesOf(Model\User::class, $response);
     }
 }


### PR DESCRIPTION
Closes #46 

Stumbled on the same issue so might aswel try to fix it. 

It was odd I have to do 

```PHP
$response = $this->graph->createCollectionRequest("GET", $endpoint)
                        ->setReturnType(User::class)
                        ->execute();

if(!is_array($users)) {

}
```
and not
```PHP
$response = $this->graph->createCollectionRequest("GET", $endpoint)
                        ->setReturnType(User::class)
                        ->execute();

if(count($response) == 0) {}
//or
if(empty($response)) {}
```