### PR TITLE
October 2018 release - Added the ItemPreviewInfo type for use by DriveItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can install the PHP SDK with Composer, either run `composer require microsof
 ```
 {
     "require": {
-        "microsoft/microsoft-graph": "^1.0"
+        "microsoft/microsoft-graph": "^1.5"
     }
 }
 ```

--- a/src/Core/GraphConstants.php
+++ b/src/Core/GraphConstants.php
@@ -9,7 +9,7 @@
 *
 * @category  Library
 * @package   Microsoft.Graph
-* @copyright 2016 Microsoft Corporation
+* @copyright 2018 Microsoft Corporation
 * @license   https://opensource.org/licenses/MIT MIT License
 * @version   GIT: 1.0.0
 * @link      https://graph.microsoft.io/
@@ -24,7 +24,7 @@ final class GraphConstants
     const REST_ENDPOINT = "https://graph.microsoft.com/";
 
     // Define HTTP request constants
-    const SDK_VERSION = "1.4.0";
+    const SDK_VERSION = "1.5.0";
 
     // Define error constants
     const MAX_PAGE_SIZE = 999;

--- a/src/Model/ItemPreviewInfo.php
+++ b/src/Model/ItemPreviewInfo.php
@@ -1,0 +1,106 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* ItemPreviewInfo File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @version   GIT: 1.5.0
+* @link      https://graph.microsoft.io/
+*/
+namespace Microsoft\Graph\Model;
+/**
+* ItemPreviewInfo class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @version   Release: 1.5.0
+* @link      https://graph.microsoft.io/
+*/
+class ItemPreviewInfo extends Entity
+{
+    /**
+    * Gets the getUrl
+    *
+    * @return string The getUrl
+    */
+    public function getGetUrl()
+    {
+        if (array_key_exists("getUrl", $this->_propDict)) {
+            return $this->_propDict["getUrl"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the getUrl
+    *
+    * @param string $val The value of the getUrl
+    *
+    * @return ItemPreviewInfo
+    */
+    public function setGetUrl($val)
+    {
+        $this->_propDict["getUrl"] = $val;
+        return $this;
+    }
+    /**
+    * Gets the postParameters
+    *
+    * @return string The postParameters
+    */
+    public function getPostParameters()
+    {
+        if (array_key_exists("postParameters", $this->_propDict)) {
+            return $this->_propDict["postParameters"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the postParameters
+    *
+    * @param string $val The value of the postParameters
+    *
+    * @return ItemPreviewInfo
+    */
+    public function setPostParameters($val)
+    {
+        $this->_propDict["postParameters"] = $val;
+        return $this;
+    }
+    /**
+    * Gets the postUrl
+    *
+    * @return string The postUrl
+    */
+    public function getPostUrl()
+    {
+        if (array_key_exists("postUrl", $this->_propDict)) {
+            return $this->_propDict["postUrl"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the postUrl
+    *
+    * @param string $val The value of the postUrl
+    *
+    * @return ItemPreviewInfo
+    */
+    public function setPostUrl($val)
+    {
+        $this->_propDict["postUrl"] = $val;
+        return $this;
+    }
+}


### PR DESCRIPTION
PHP changes goint in the next release.

New ItemPreviewInfo type added. (this PR)

* (previous PR) - Added exception information for core library. https://github.com/microsoftgraph/msgraph-sdk-php/pull/110/files
* (previous PR) - Added odata.Type to base types. https://github.com/microsoftgraph/msgraph-sdk-php/pull/104/files