### PR TITLE
Fixes #130

### DIFF
--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -299,7 +299,7 @@ class GraphRequest
             function ($result) {
 
                 // Check to see if returnType is a stream, if so return it immediately
-                if($this->returnStream) {
+                if($this->returnsStream) {
                     return $result->getBody();
                 }
 

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -247,10 +247,14 @@ class GraphRequest
             $this->_getRequestUrl(), 
             [
                 'body' => $this->requestBody,
-                'stream' =>  $this->returnsStream,
                 'timeout' => $this->timeout
             ]
         );
+
+        // Check to see if returnType is a stream, if so return it immediately
+        if($this->returnStream) {
+            return $result->getBody();
+        }
 
         // Wrap response in GraphResponse layer
         $response = new GraphResponse(
@@ -288,12 +292,17 @@ class GraphRequest
             $this->_getRequestUrl(),
             [
                 'body' => $this->requestBody,
-                'stream' => $this->returnsStream,
                 'timeout' => $this->timeout
             ]
         )->then(
             // On success, return the result/response
             function ($result) {
+
+                // Check to see if returnType is a stream, if so return it immediately
+                if($this->returnStream) {
+                    return $result->getBody();
+                }
+
                 $response = new GraphResponse(
                     $this, 
                     $result->getBody(), 

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -252,7 +252,7 @@ class GraphRequest
         );
 
         // Check to see if returnType is a stream, if so return it immediately
-        if($this->returnStream) {
+        if($this->returnsStream) {
             return $result->getBody();
         }
 

--- a/src/Http/GraphResponse.php
+++ b/src/Http/GraphResponse.php
@@ -139,10 +139,6 @@ class GraphResponse
         $class = $returnType;
         $result = $this->getBody();
 
-        if ($returnType == "GuzzleHttp\Psr7\Stream") {
-              return $this->_body;  
-        }
-
         //If more than one object is returned
         if (array_key_exists('value', $result)) {
             $objArray = array();

--- a/tests/Functional/OnedriveTest.php
+++ b/tests/Functional/OnedriveTest.php
@@ -48,7 +48,7 @@ class OnedriveTest extends TestCase
     			$driveItemContent = $this->_client->createRequest("GET", "/me/drive/items/$itemId/content")
     									          ->setReturnType(GuzzleHttp\Psr7\Stream::class)
     									          ->execute();
-    			$this->assertNotNull($driveItemContent);
+				$this->assertNotEmpty((String)$driveItemContent->getContent());
     		}
     	}
     }

--- a/tests/Functional/OnedriveTest.php
+++ b/tests/Functional/OnedriveTest.php
@@ -48,7 +48,7 @@ class OnedriveTest extends TestCase
     			$driveItemContent = $this->_client->createRequest("GET", "/me/drive/items/$itemId/content")
     									          ->setReturnType(GuzzleHttp\Psr7\Stream::class)
     									          ->execute();
-				$this->assertNotEmpty((String)$driveItemContent->getContent());
+				$this->assertNotEmpty((String)$driveItemContent);
     		}
     	}
     }


### PR DESCRIPTION
This PR fixes the ability to handle redirects when a stream is the returnType and returns the stream immediately instead of first wrapping it into a GraphResponse (which exhausts the stream).