### PR TITLE
Prevent Running array_key_exists on null

### DIFF
--- a/src/Model/PatternedRecurrence.php
+++ b/src/Model/PatternedRecurrence.php
@@ -34,7 +34,7 @@ class PatternedRecurrence extends Entity
     */
     public function getPattern()
     {
-        if ($this->->getProperties() && array_key_exists("pattern", $this->_propDict)) {
+        if ($this->getProperties() && array_key_exists("pattern", $this->_propDict)) {
             if (is_a($this->_propDict["pattern"], "Microsoft\Graph\Model\RecurrencePattern")) {
                 return $this->_propDict["pattern"];
             } else {
@@ -67,7 +67,7 @@ class PatternedRecurrence extends Entity
     */
     public function getRange()
     {
-        if ($this->->getProperties() && array_key_exists("range", $this->_propDict)) {
+        if ($this->getProperties() && array_key_exists("range", $this->_propDict)) {
             if (is_a($this->_propDict["range"], "Microsoft\Graph\Model\RecurrenceRange")) {
                 return $this->_propDict["range"];
             } else {

--- a/src/Model/PatternedRecurrence.php
+++ b/src/Model/PatternedRecurrence.php
@@ -34,7 +34,7 @@ class PatternedRecurrence extends Entity
     */
     public function getPattern()
     {
-        if (array_key_exists("pattern", $this->_propDict)) {
+        if ($this->->getProperties() && array_key_exists("pattern", $this->_propDict)) {
             if (is_a($this->_propDict["pattern"], "Microsoft\Graph\Model\RecurrencePattern")) {
                 return $this->_propDict["pattern"];
             } else {
@@ -67,7 +67,7 @@ class PatternedRecurrence extends Entity
     */
     public function getRange()
     {
-        if (array_key_exists("range", $this->_propDict)) {
+        if ($this->->getProperties() && array_key_exists("range", $this->_propDict)) {
             if (is_a($this->_propDict["range"], "Microsoft\Graph\Model\RecurrenceRange")) {
                 return $this->_propDict["range"];
             } else {


### PR DESCRIPTION
_propDict can sometimes be overwritten in normal operation (no setters used) and become null.  This causes the array_key_exists checks to throw a fatal error.  _propDict should be checked to make sure it is not null before looking for the key.