### PR TITLE
Fixed class name in Drive::getList()

### DIFF
--- a/src/Model/Drive.php
+++ b/src/Model/Drive.php
@@ -224,7 +224,7 @@ class Drive extends BaseItem
     public function getList()
     {
         if (array_key_exists("list", $this->_propDict)) {
-            if (is_a($this->_propDict["list"], "Microsoft\Graph\Model\List")) {
+            if (is_a($this->_propDict["list"], "Microsoft\Graph\Model\GraphList")) {
                 return $this->_propDict["list"];
             } else {
                 $this->_propDict["list"] = new GraphList($this->_propDict["list"]);


### PR DESCRIPTION
Fixed wrong class name in Drive::getList()