### PR TITLE
Doc update - fix ms to seconds

### DIFF
--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -216,7 +216,7 @@ class GraphRequest
     /**
     * Sets the timeout limit of the cURL request
     *
-    * @param string $timeout The timeout in ms
+    * @param string $timeout The timeout in seconds
     * 
     * @return GraphRequest object
     */


### PR DESCRIPTION
GraphRequest->setTimeout param description was incorrectly describes "ms" (milliseconds), but according to guzzle client docs http://docs.guzzlephp.org/en/stable/request-options.html#timeout it's actually seconds.