### PR TITLE
Remove phpDocumentor from composer.json - unblock SDK generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^7.5 || ^8.0",
-		"phpdocumentor/phpdocumentor": "^2.9",
 		"mikey179/vfsstream": "^1.2"
 	},
 	"autoload": {


### PR DESCRIPTION
After we upgraded to php8.0, phpDocumentor started to fail in `composer install` step.

According to phpDocumentor documentation, installing the package via composer is not recommended:
https://github.com/phpDocumentor/phpDocumentor#via-composer-not-recommended

Another data point is that the last update to our docs are from 4 years ago. So we don't need phpDocumentor in `require-dev` category at least in the foreseeable future. There are other ways to run the doc generator if we decide to do so.

Fixes https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/453 and unblocks SDK generation for PHP.

Successful generation run: https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=40880&view=results