### PR TITLE
Add missing backslash for namespace

### DIFF
--- a/src/CallRecords/Model/CallRecord.php
+++ b/src/CallRecords/Model/CallRecord.php
@@ -161,7 +161,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
             if (is_a($this->_propDict["organizer"], "Microsoft\Graph\Model\IdentitySet")) {
                 return $this->_propDict["organizer"];
             } else {
-                $this->_propDict["organizer"] = new Microsoft\Graph\Model\IdentitySet($this->_propDict["organizer"]);
+                $this->_propDict["organizer"] = new \Microsoft\Graph\Model\IdentitySet($this->_propDict["organizer"]);
                 return $this->_propDict["organizer"];
             }
         }


### PR DESCRIPTION
Currently `getOrganizer()` will throw an error "Class 'Microsoft\Graph\CallRecords\Model\Microsoft\Graph\Model\IdentitySet' not found"