### PR TITLE
HOT FIX: Wrap Guzzle BadResponseExceptions by extending Guzzle exception classes

### DIFF
--- a/src/Exception/GraphRequestException.php
+++ b/src/Exception/GraphRequestException.php
@@ -1,0 +1,50 @@
+<?php 
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  
+* Licensed under the MIT License.  See License in the project root 
+* for license information.
+* 
+* Exceptions File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright 2016 Microsoft Corporation
+* @license   https://opensource.org/licenses/MIT MIT License
+* @version   GIT: 0.1.0
+* @link      https://graph.microsoft.io/
+*/
+
+namespace Microsoft\Graph\Exception;
+
+/**
+ * Class GraphRequestException
+ *
+ * @category Library
+ * @package  Microsoft.Graph
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     https://graph.microsoft.io/
+ */
+class GraphRequestException extends \GuzzleHttp\Exception\ClientException
+{
+    /**
+    * Construct a new GraphRequestException from it' parent ClientException
+    *
+    * @param string    $message  The error to send
+    * @param \GuzzleHttp\Exception\ClientException  $ex The parent exception
+    */
+    public function __construct($message, \GuzzleHttp\Exception\ClientException $ex)
+    {
+        parent::__construct($message, $ex->getRequest(), $ex->getResponse(), $ex, $ex->getHandlerContext());
+    }
+
+    /**
+    * Stringify the returned error and message
+    *
+    * @return string The returned string message
+    */
+    public function __toString()
+    {
+        return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
+    }
+}

--- a/src/Exception/GraphServerException.php
+++ b/src/Exception/GraphServerException.php
@@ -1,0 +1,50 @@
+<?php 
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  
+* Licensed under the MIT License.  See License in the project root 
+* for license information.
+* 
+* Exceptions File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright 2016 Microsoft Corporation
+* @license   https://opensource.org/licenses/MIT MIT License
+* @version   GIT: 0.1.0
+* @link      https://graph.microsoft.io/
+*/
+
+namespace Microsoft\Graph\Exception;
+
+/**
+ * Class GraphServerException
+ *
+ * @category Library
+ * @package  Microsoft.Graph
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     https://graph.microsoft.io/
+ */
+class GraphServerException extends \GuzzleHttp\Exception\ServerException
+{
+    /**
+    * Construct a new GraphServerException handler from a Guzzle ServerException
+    *
+    * @param string $message  The error to send
+    * @param \GuzzleHttp\Exception\ServerException $ex The parent Server Exception
+    */
+    public function __construct(string $message, \GuzzleHttp\Exception\ServerException $ex)
+    {
+        parent::__construct($message, $ex->getRequest(), $ex->getResponse(), $ex, $ex->getHandlerContext());
+    }
+
+    /**
+    * Stringify the returned error and message
+    *
+    * @return string The returned string message
+    */
+    public function __toString()
+    {
+        return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
+    }
+}

--- a/tests/Core/ExceptionWrapperTest.php
+++ b/tests/Core/ExceptionWrapperTest.php
@@ -1,33 +1,41 @@
 <?php
 
-use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Microsoft\Graph\Core\ExceptionWrapper;
-use Microsoft\Graph\Exception\GraphException;
 use PHPUnit\Framework\TestCase;
 
 class ExceptionWrapperTest extends TestCase
 {
-    public function testWrapBadResponseExceptionReturnsGraphException()
+    public function testWrapGuzzleClientExceptionReturnsClientException()
     {
         $responseBody = json_encode(array('body' => 'content'));
-        $ex = new BadResponseException("Error: API returned 400", new Request("GET", "/endpoint"), new Response(400, [], $responseBody));
-        $graphException = ExceptionWrapper::wrapGuzzleBadResponseException($ex);
-        $this->assertInstanceOf(GraphException::class, $graphException);
+        $ex = new \GuzzleHttp\Exception\ClientException("Error: API returned 400", new Request("GET", "/endpoint"), new Response(400, [], $responseBody));
+        $graphException = ExceptionWrapper::wrapGuzzleClientException($ex);
+        $this->assertInstanceOf(\GuzzleHttp\Exception\ClientException::class, $graphException);
     }
 
-    public function testWrapBadResponseExceptionHasResponseBody()
+    public function testWrapGuzzleServerExceptionReturnsServerException()
     {
         $responseBody = json_encode(array('body' => 'content'));
-        $ex = new BadResponseException("Error: API returned 400", new Request("GET", "/endpoint"), new Response(400, [], $responseBody));
-        $graphException = ExceptionWrapper::wrapGuzzleBadResponseException($ex);
+        $ex = new \GuzzleHttp\Exception\ServerException("Error: API returned 500", new Request("GET", "/endpoint"), new Response(500, [], $responseBody));
+        $graphException = ExceptionWrapper::wrapGuzzleServerException($ex);
+        $this->assertInstanceOf(\GuzzleHttp\Exception\ServerException::class, $graphException);
+    }
+
+    public function testWrapGuzzleClientExceptionHasResponseBody()
+    {
+        $responseBody = json_encode(array('body' => 'content'));
+        $ex = new \GuzzleHttp\Exception\ClientException("Error: API returned 400", new Request("GET", "/endpoint"), new Response(400, [], $responseBody));
+        $graphException = ExceptionWrapper::wrapGuzzleClientException($ex);
         $this->assertStringContainsString($responseBody, $graphException->getMessage());
     }
 
-    public function testWrapBadResponseExceptionWithInvalidInput()
+    public function testWrapGuzzleServerExceptionHasResponseBody()
     {
-        $this->expectException(TypeError::class);
-        ExceptionWrapper::wrapGuzzleBadResponseException(null);
+        $responseBody = json_encode(array('body' => 'content'));
+        $ex = new \GuzzleHttp\Exception\ServerException("Error: API returned 500", new Request("GET", "/endpoint"), new Response(500, [], $responseBody));
+        $graphException = ExceptionWrapper::wrapGuzzleServerException($ex);
+        $this->assertStringContainsString($responseBody, $graphException->getMessage());
     }
 }

--- a/tests/Http/GraphRequestTest.php
+++ b/tests/Http/GraphRequestTest.php
@@ -3,7 +3,8 @@
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Microsoft\Graph\Core\GraphConstants;
-use Microsoft\Graph\Exception\GraphException;
+use Microsoft\Graph\Exception\GraphRequestException;
+use Microsoft\Graph\Exception\GraphServerException;
 use Microsoft\Graph\Graph;
 use Microsoft\Graph\Http\GraphRequest;
 use Microsoft\Graph\Http\Test\MockClientFactory;
@@ -204,7 +205,7 @@ class GraphRequestTest extends TestCase
 
     public function testExecuteWith4xxResponse()
     {
-        $this->expectException(GraphException::class);
+        $this->expectException(GraphRequestException::class);
         $mockResponse = array(new Response(400));
         $client = MockClientFactory::create(['http_errors' => true], $mockResponse);
         $this->requests[0]->execute($client);
@@ -212,7 +213,7 @@ class GraphRequestTest extends TestCase
 
     public function testExecuteWith5xxResponse()
     {
-        $this->expectException(GraphException::class);
+        $this->expectException(GraphServerException::class);
         $mockResponse = array(new Response(500));
         $client = MockClientFactory::create(['http_errors' => true], $mockResponse);
         $this->requests[0]->execute($client);

--- a/tests/Http/HttpTest.php
+++ b/tests/Http/HttpTest.php
@@ -1,12 +1,11 @@
 <?php
 use PHPUnit\Framework\TestCase;
-use Microsoft\Graph\Graph;
 use Microsoft\Graph\Http\GraphRequest;
-use Microsoft\Graph\Exception\GraphException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Client;
+use Microsoft\Graph\Exception\GraphRequestException;
 
 class HttpTest extends TestCase
 {
@@ -84,7 +83,7 @@ class HttpTest extends TestCase
 
     public function testInvalidVerb()
     {
-        $this->expectException(GraphException::class);
+        $this->expectException(GraphRequestException::class);
 
         $mock = new MockHandler([
             new Response(400, ['foo' => 'bar'])


### PR DESCRIPTION
A breaking change was made as reported in #451.

We did not correctly wrap the Guzzle exceptions but rather created a new exception type that breaks customer's code.

The changes below create new Graph exception classes that inherit the Guzzle exception types that they wrap. This way customers who previously handled the Guzzle exceptions themselves can still do so and customers who were unable to handle the Guzzle exceptions have a Graph exception that has all the info they need in the exception message.

Challenge is that this fix would be a breaking change for a customer already using the previous 1.30.0 solution. Not sure how to handle this situation.

Closes #451 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/452)