### PR TITLE
HOT FIX: Fix BC break in "Fix truncated error messages"

### DIFF
--- a/src/Http/GraphCollectionRequest.php
+++ b/src/Http/GraphCollectionRequest.php
@@ -97,6 +97,7 @@ class GraphCollectionRequest extends GraphRequest
 	 *
 	 * @return int the number of entries
 	 * @throws GraphException
+	 * @throws \GuzzleHttp\Exception\GuzzleException
 	 */
     public function count()
     {
@@ -143,7 +144,7 @@ class GraphCollectionRequest extends GraphRequest
 	 * Gets the next page of results
 	 *
 	 * @return array of objects of class $returnType
-	 * @throws GraphException
+	 * @throws \GuzzleHttp\Exception\GuzzleException
 	 */
     public function getPage()
     {

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -293,7 +293,7 @@ class GraphRequest
     *
     * @param mixed $client The client to use in the request
     *
-    * @throws GraphException if response is invalid; if 4xx/5xx is returned and $http_errors is true
+    * @throws \GuzzleHttp\Exception\GuzzleException
     *
     * @return mixed object or array of objects
     *         of class $returnType
@@ -401,8 +401,9 @@ class GraphRequest
     * @param string $path   The path to download the file to
     * @param mixed  $client The client to use in the request
     *
-     * @throws GraphException if file path is invalid; if \GuzzleHttp\Exception\BadResponseException is thrown for 4xx/5xx responses
-     *
+    * @throws GraphException if file path is invalid
+    * @throws \GuzzleHttp\Exception\GuzzleException
+    *
     * @return null
     */
     public function download($path, $client = null)
@@ -444,8 +445,9 @@ class GraphRequest
     * @param string $path   The path of the file to upload
     * @param mixed  $client The client to use in the request
     *
-     * @throws GraphException if file is invalid
-     *
+    * @throws GraphException if file is invalid
+    * @throws \GuzzleHttp\Exception\GuzzleException
+    *
     * @return mixed DriveItem or array of DriveItems
     */
     public function upload($path, $client = null)

--- a/tests/Core/ExceptionWrapperTest.php
+++ b/tests/Core/ExceptionWrapperTest.php
@@ -1,28 +1,86 @@
 <?php
-
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Microsoft\Graph\Core\ExceptionWrapper;
-use Microsoft\Graph\Exception\GraphException;
 use PHPUnit\Framework\TestCase;
 
 class ExceptionWrapperTest extends TestCase
 {
-    public function testWrapBadResponseExceptionReturnsGraphException()
+    protected $responseBodies;
+    protected $autoBadResponseExceptions;
+    protected $manualBadResponseExceptions;
+
+    public function setUp(): void
     {
-        $responseBody = json_encode(array('body' => 'content'));
-        $ex = new BadResponseException("Error: API returned 400", new Request("GET", "/endpoint"), new Response(400, [], $responseBody));
-        $graphException = ExceptionWrapper::wrapGuzzleBadResponseException($ex);
-        $this->assertInstanceOf(GraphException::class, $graphException);
+        $this->responseBodies = array(
+            'short' => json_encode(array('body' => 'content')), // not truncated by Guzzle
+            'long' => json_encode(array('body' => base64_encode(random_bytes(120)) . '.')), // truncated by Guzzle
+        );
+
+        $this->autoBadResponseExceptions = array();
+        $this->manualBadResponseExceptions = array();
+        foreach ($this->responseBodies as $name => $responseBody) {
+            $autoBadResponseException = GuzzleHttp\Exception\RequestException::create(new Request("GET", "/endpoint"), new Response(400, [], $responseBody));
+            assert($autoBadResponseException instanceof BadResponseException);
+            $this->autoBadResponseExceptions[$name] = $autoBadResponseException;
+
+            $manualBadResponseException = new BadResponseException("Error: API returned 400", new Request("GET", "/endpoint"), new Response(400, [], $responseBody));
+            $this->manualBadResponseExceptions[$name] = $manualBadResponseException;
+        }
     }
 
-    public function testWrapBadResponseExceptionHasResponseBody()
+    public function testWrapBadResponseExceptionReturnsInstanceOfSameClass()
     {
-        $responseBody = json_encode(array('body' => 'content'));
-        $ex = new BadResponseException("Error: API returned 400", new Request("GET", "/endpoint"), new Response(400, [], $responseBody));
-        $graphException = ExceptionWrapper::wrapGuzzleBadResponseException($ex);
-        $this->assertStringContainsString($responseBody, $graphException->getMessage());
+        $name = 'short';
+
+        $ex = $this->autoBadResponseExceptions[$name];
+        $wrappedException = ExceptionWrapper::wrapGuzzleBadResponseException($ex);
+        $this->assertInstanceOf(get_class($ex), $wrappedException);
+
+        $ex = $this->manualBadResponseExceptions[$name];
+        $wrappedException = ExceptionWrapper::wrapGuzzleBadResponseException($ex);
+        $this->assertInstanceOf(get_class($ex), $wrappedException);
+
+        $name = 'long';
+
+        $ex = $this->autoBadResponseExceptions[$name];
+        $wrappedException = ExceptionWrapper::wrapGuzzleBadResponseException($ex);
+        $this->assertInstanceOf(get_class($ex), $wrappedException);
+
+        $ex = $this->manualBadResponseExceptions[$name];
+        $wrappedException = ExceptionWrapper::wrapGuzzleBadResponseException($ex);
+        $this->assertInstanceOf(get_class($ex), $wrappedException);
+    }
+
+    public function testWrapAutoBadResponseExceptionHasResponseBody()
+    {
+        $name = 'short';
+        $responseBody = $this->responseBodies[$name];
+        $ex = $this->autoBadResponseExceptions[$name];
+        $wrappedException = ExceptionWrapper::wrapGuzzleBadResponseException($ex);
+        $this->assertStringContainsString($responseBody, $wrappedException->getMessage());
+
+        $name = 'long';
+        $responseBody = $this->responseBodies[$name];
+        $ex = $this->autoBadResponseExceptions[$name];
+        $wrappedException = ExceptionWrapper::wrapGuzzleBadResponseException($ex);
+        $this->assertStringContainsString($responseBody, $wrappedException->getMessage());
+    }
+
+    public function testWrapManualBadResponseExceptionHasNotResponseBody()
+    {
+        $name = 'short';
+        $responseBody = $this->responseBodies[$name];
+        $ex = $this->manualBadResponseExceptions[$name];
+        $wrappedException = ExceptionWrapper::wrapGuzzleBadResponseException($ex);
+        $this->assertStringNotContainsString($responseBody, $wrappedException->getMessage());
+
+        $name = 'long';
+        $responseBody = $this->responseBodies[$name];
+        $ex = $this->manualBadResponseExceptions[$name];
+        $wrappedException = ExceptionWrapper::wrapGuzzleBadResponseException($ex);
+        $this->assertStringNotContainsString($responseBody, $wrappedException->getMessage());
     }
 
     public function testWrapBadResponseExceptionWithInvalidInput()

--- a/tests/Http/GraphRequestTest.php
+++ b/tests/Http/GraphRequestTest.php
@@ -1,9 +1,7 @@
 <?php
-
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Microsoft\Graph\Core\GraphConstants;
-use Microsoft\Graph\Exception\GraphException;
 use Microsoft\Graph\Graph;
 use Microsoft\Graph\Http\GraphRequest;
 use Microsoft\Graph\Http\Test\MockClientFactory;
@@ -170,6 +168,11 @@ class GraphRequestTest extends TestCase
                          ->executeAsync($this->client);
         $this->assertInstanceOf(GuzzleHttp\Promise\PromiseInterface::class, $promise);
 
+        $promise = $this->requests[0]
+                         ->executeAsync($this->client);
+        $promise2 = $this->requests[2]
+                          ->executeAsync($this->client);
+
         $response = \GuzzleHttp\Promise\unwrap(array($promise));
         foreach ($response as $responseItem) {
             $this->assertInstanceOf(Microsoft\Graph\Http\GraphResponse::class, $responseItem);
@@ -204,7 +207,7 @@ class GraphRequestTest extends TestCase
 
     public function testExecuteWith4xxResponse()
     {
-        $this->expectException(GraphException::class);
+        $this->expectException(GuzzleHttp\Exception\ClientException::class);
         $mockResponse = array(new Response(400));
         $client = MockClientFactory::create(['http_errors' => true], $mockResponse);
         $this->requests[0]->execute($client);
@@ -212,12 +215,12 @@ class GraphRequestTest extends TestCase
 
     public function testExecuteWith5xxResponse()
     {
-        $this->expectException(GraphException::class);
+        $this->expectException(GuzzleHttp\Exception\ServerException::class);
         $mockResponse = array(new Response(500));
         $client = MockClientFactory::create(['http_errors' => true], $mockResponse);
         $this->requests[0]->execute($client);
     }
-    
+
     public function testExecuteAsyncWithBadResponseTriggersNotice()
     {
         $this->expectNotice();

--- a/tests/Http/HttpTest.php
+++ b/tests/Http/HttpTest.php
@@ -84,7 +84,7 @@ class HttpTest extends TestCase
 
     public function testInvalidVerb()
     {
-        $this->expectException(GraphException::class);
+        $this->expectException(GuzzleHttp\Exception\ClientException::class);
 
         $mock = new MockHandler([
             new Response(400, ['foo' => 'bar'])


### PR DESCRIPTION
Closes #451
Partially reverts #437

We just want the full (non-truncated) response body in the message, not change the exception type.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/453)