### PR TITLE
Allow SSL verification when using a proxy

### DIFF
--- a/src/Graph.php
+++ b/src/Graph.php
@@ -61,6 +61,13 @@ class Graph
     private $_proxyPort;
 
     /**
+     * Whether SSL verification should be used for proxy requests
+     *
+     * @var bool
+     */
+    private $_proxyVerifySSL;
+
+    /**
     * Creates a new Graph object, which is used to call the Graph API
     */
     public function __construct()
@@ -116,12 +123,15 @@ class Graph
     * requests and responses made with Guzzle
     *
     * @param string port The port number to use
+    * @param bool $verifySSL Whether SSL verification should be enabled
     *
     * @return Graph object
     */
-    public function setProxyPort($port)
+    public function setProxyPort($port, $verifySSL = false)
     {
         $this->_proxyPort = $port;
+        $this->_proxyVerifySSL = $verifySSL;
+
         return $this;
     }
 
@@ -143,7 +153,8 @@ class Graph
             $this->_accessToken,
             $this->_baseUrl,
             $this->_apiVersion,
-            $this->_proxyPort
+            $this->_proxyPort,
+            $this->_proxyVerifySSL
         );
     }
 
@@ -166,7 +177,8 @@ class Graph
             $this->_accessToken,
             $this->_baseUrl,
             $this->_apiVersion,
-            $this->_proxyPort
+            $this->_proxyPort,
+            $this->_proxyVerifySSL
         );
     }
 }

--- a/src/Http/GraphCollectionRequest.php
+++ b/src/Http/GraphCollectionRequest.php
@@ -70,16 +70,17 @@ class GraphCollectionRequest extends GraphRequest
     /**
     * Constructs a new GraphCollectionRequest object
     *
-    * @param string $requestType The HTTP verb for the
-    *                            request ("GET", "POST", "PUT", etc.)
-    * @param string $endpoint    The URI of the endpoint to hit
-    * @param string $accessToken A valid access token
-    * @param string $baseUrl     The base URL of the request
-    * @param string $apiVersion  The version of the API to call
-    * @param string $proxyPort   The url where to proxy through
+    * @param string $requestType  The HTTP verb for the
+    *                             request ("GET", "POST", "PUT", etc.)
+    * @param string $endpoint     The URI of the endpoint to hit
+    * @param string $accessToken  A valid access token
+    * @param string $baseUrl      The base URL of the request
+    * @param string $apiVersion   The version of the API to call
+    * @param string $proxyPort    The url where to proxy through
+    * @param bool $proxyVerifySSL Whether the proxy requests should perform SSL verification
     * @throws GraphException when no access token is provided
     */
-    public function __construct($requestType, $endpoint, $accessToken, $baseUrl, $apiVersion, $proxyPort = null)
+    public function __construct($requestType, $endpoint, $accessToken, $baseUrl, $apiVersion, $proxyPort = null, $proxyVerifySSL = false)
     {
         parent::__construct(
             $requestType,
@@ -87,7 +88,8 @@ class GraphCollectionRequest extends GraphRequest
             $accessToken,
             $baseUrl,
             $apiVersion,
-            $proxyPort
+            $proxyPort,
+            $proxyVerifySSL
         );
         $this->end = false;
     }

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -110,15 +110,16 @@ class GraphRequest
     /**
     * Constructs a new Graph Request object
     *
-    * @param string $requestType The HTTP method to use, e.g. "GET" or "POST"
-    * @param string $endpoint    The Graph endpoint to call
-    * @param string $accessToken A valid access token to validate the Graph call
-    * @param string $baseUrl     The base URL to call
-    * @param string $apiVersion  The API version to use
-    * @param string $proxyPort   The url where to proxy through
+    * @param string $requestType  The HTTP method to use, e.g. "GET" or "POST"
+    * @param string $endpoint     The Graph endpoint to call
+    * @param string $accessToken  A valid access token to validate the Graph call
+    * @param string $baseUrl      The base URL to call
+    * @param string $apiVersion   The API version to use
+    * @param string $proxyPort    The url where to proxy through
+    * @param bool $proxyVerifySSL Whether the proxy requests should perform SSL verification
     * @throws GraphException when no access token is provided
     */
-    public function __construct($requestType, $endpoint, $accessToken, $baseUrl, $apiVersion, $proxyPort = null)
+    public function __construct($requestType, $endpoint, $accessToken, $baseUrl, $apiVersion, $proxyPort = null, $proxyVerifySSL = false)
     {
         $this->requestType = $requestType;
         $this->endpoint = $endpoint;
@@ -134,6 +135,7 @@ class GraphRequest
         $this->timeout = 100;
         $this->headers = $this->_getDefaultHeaders();
         $this->proxyPort = $proxyPort;
+        $this->proxyVerifySSL = $proxyVerifySSL;
     }
 
     /**
@@ -535,7 +537,7 @@ class GraphRequest
             'headers' => $this->headers
         ];
         if ($this->proxyPort !== null) {
-            $clientSettings['verify'] = false;
+            $clientSettings['verify'] = $this->proxyVerifySSL;
             $clientSettings['proxy'] = $this->proxyPort;
         }
         $client = new Client($clientSettings);

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -101,6 +101,12 @@ class GraphRequest
     */
     protected $proxyPort;
     /**
+     * Whether SSL verification should be used for proxy requests
+     *
+     * @var bool
+     */
+    protected $proxyVerifySSL;
+    /**
     * Request options to decide if Guzzle Client should throw exceptions when http code is 4xx or 5xx
     *
     * @var bool


### PR DESCRIPTION
In some cases (ie enterprise environments), a user might need to use a
proxy to make the outbound requests. This allows those users to use a
proxy but *without* turning off SSL verification

Fixes #460

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/476)