### PR TITLE
Remove default assignment of code generation PRs

### DIFF
--- a/.github/workflows/create-beta-pull-request.yml
+++ b/.github/workflows/create-beta-pull-request.yml
@@ -38,12 +38,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         MESSAGE_TITLE: Generated beta models using Typewriter
         MESSAGE_BODY: "This pull request was automatically created by the GitHub Action, **${{github.workflow}}**. \n\n The commit hash is _${{github.sha}}_. \n\n **Important** Check for unexpected deletions or changes in this PR. See [beta_metadata.xml](https://github.com/microsoftgraph/msgraph-metadata/blob/master/beta_metadata.xml) for metadata changes. \n\n Make sure the version number is incremented in /src/Core/GraphConstants.php. Compare the version against the latest release on [packagist.org](https://packagist.org/packages/microsoft/microsoft-graph) and update the version in src/Core/GraphConstants."
-        ASSIGNEDTO: Ndiritu,silaskenneth
         LABELS: generated
         BASE: dev
       run: |
         curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-        bin/hub pull-request -b "$BASE" -h "$GITHUB_REF" -m "$MESSAGE_TITLE" -m "$MESSAGE_BODY" -r "$REVIEWERS" -a "$ASSIGNEDTO" -l "$LABELS"
+        bin/hub pull-request -b "$BASE" -h "$GITHUB_REF" -m "$MESSAGE_TITLE" -m "$MESSAGE_BODY" -r "$REVIEWERS" -l "$LABELS"
 # References
 # [0] https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
 # [1] https://hub.github.com/hub-pull-request.1.html

--- a/.github/workflows/create-v1.0-pull-request.yml
+++ b/.github/workflows/create-v1.0-pull-request.yml
@@ -40,12 +40,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         MESSAGE_TITLE: Generated models using Typewriter
         MESSAGE_BODY: "This pull request was automatically created by the GitHub Action, **${{github.workflow}}**. \n\n The commit hash is _${{github.sha}}_. \n\n **Important** Check for unexpected deletions or changes in this PR. See [v1.0_metadata.xml](https://github.com/microsoftgraph/msgraph-metadata/blob/master/v1.0_metadata.xml) for metadata changes. \n\n Make sure the version number is incremented in /src/Core/GraphConstants.php. Compare the version against the latest release on [packagist.org](https://packagist.org/packages/microsoft/microsoft-graph) and update the version in src/Core/GraphConstants."
-        ASSIGNEDTO: Ndiritu,silaskenneth
         LABELS: generated
         BASE: dev
       run: |
         curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-        bin/hub pull-request -b "$BASE" -h "$GITHUB_REF" -m "$MESSAGE_TITLE" -m "$MESSAGE_BODY" -r "$REVIEWERS" -a "$ASSIGNEDTO" -l "$LABELS"
+        bin/hub pull-request -b "$BASE" -h "$GITHUB_REF" -m "$MESSAGE_TITLE" -m "$MESSAGE_BODY" -r "$REVIEWERS" -l "$LABELS"
 # References
 # [0] https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
 # [1] https://hub.github.com/hub-pull-request.1.html


### PR DESCRIPTION
It's now possible to trigger pr-validation steps for code generation PRs by manually assigning yourself the PR.
Removing the default assignment allows Kenneth & I to manually assign ourselves the PRs to trigger the validation steps instead of un-assigning ourselves first.

Reverts change made in #466

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/482)