### PR TITLE
Extract nextLink endpoint from full url correctly

### DIFF
--- a/src/Http/GraphCollectionRequest.php
+++ b/src/Http/GraphCollectionRequest.php
@@ -175,8 +175,7 @@ class GraphCollectionRequest extends GraphRequest
         }
 
         if ($this->nextLink) {
-            $baseLength = strlen($this->baseUrl) + strlen($this->apiVersion);
-            $this->endpoint = substr($this->nextLink, $baseLength);
+            $this->endpoint = "/" . implode("/", array_slice(explode("/", $this->nextLink), 4));
         } else {
             // This is the first request to the endpoint
             if ($this->pageSize) {

--- a/tests/Http/GraphCollectionRequestTest.php
+++ b/tests/Http/GraphCollectionRequestTest.php
@@ -15,7 +15,7 @@ class GraphCollectionRequestTest extends TestCase
         $this->collectionRequest->setReturnType(Model\User::class);
         $this->collectionRequest->setPageSize(2);
 
-        $body = json_encode(array('body' => 'content', '@odata.nextLink' => 'url/version/endpoint?skiptoken=link'));
+        $body = json_encode(array('body' => 'content', '@odata.nextLink' => 'https://url/version/endpoint?skiptoken=link'));
         $body2 = json_encode(array('body' => 'content'));
         $mock = new GuzzleHttp\Handler\MockHandler([
             new GuzzleHttp\Psr7\Response(200, ['foo' => 'bar'], $body),
@@ -57,7 +57,7 @@ class GraphCollectionRequestTest extends TestCase
         $this->assertInstanceOf(Microsoft\Graph\Model\User::class, $result);
     }
 
-    public function testEndpointManipulation()
+    public function testEndpointManipulationWithoutNextLink()
     {
         //Page should be 1
         $this->assertFalse($this->collectionRequest->isEnd());
@@ -70,5 +70,15 @@ class GraphCollectionRequestTest extends TestCase
 
         $requestUrl = $this->reflectedRequestUrlHandler->invokeArgs($this->collectionRequest, array());
         $this->assertEquals('version/endpoint?$top=2', $requestUrl);
+    }
+
+    public function testEndpointManipulationWhenNextLinkExists()
+    {
+        $this->collectionRequest->setPageCallInfo();
+        $response = $this->collectionRequest->execute($this->client);
+        $this->collectionRequest->processPageCallReturn($response);
+        $this->collectionRequest->setPageCallInfo();
+        $requestUrl = $this->reflectedRequestUrlHandler->invokeArgs($this->collectionRequest, array());
+        $this->assertEquals('version/endpoint?skiptoken=link', $requestUrl);
     }
 }


### PR DESCRIPTION
### Context
When making a request for the next page of a collection, we extract the endpoint from the `@odata.nextLink` in the previous page's response payload. e.g. the endpoint: `/me/calendar?$top=10&$skip=10` would be extracted from nextLink: `https://graph.microsoft.com/v1.0/me/calendar?$top=10&$skip=10`.  The endpoint is then re-appended to the baseUrl and version further down in our processing

Also, by default we set the baseUrl on a Graph object to `https://graph.microsoft.com/` (with the trailing `/`) but allow a customer to update it e.g. customer can set it to `https://graph.microsoft.com` (without the trailing `/`). When making a request, Guzzle resolves the full URL correctly regardless of the trailing slash being present or not i.e.
both 
```php
$result = $graph->setBaseUrl("https://graph.microsoft.com")->createRequest("GET", "/me")->execute();
```
and
```php
$result = $graph->createRequest("GET", "/me")->execute(); // uses default baseUrl with a trailing /
```
would resolve to the correct full URL and would return the same results

### Problem
We previously extracted the endpoint from the nextLink using the length of the baseUrl however this is not foolproof since customers are allowed to update the baseUrl on the Graph object and hence the length varies leading us to extracting the endpoint section incorrectly.

### Solution
This fix extracts the endpoint by slicing the nextLink using the `/`

Closes #160 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/488)