### PR TITLE
Replace deprecated `GuzzleHttp\Psr7\stream_for()` function

### DIFF
--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -466,7 +466,7 @@ class GraphRequest
         try {
             if (file_exists($path) && is_readable($path)) {
                 $file = fopen($path, 'r');
-                $stream = \GuzzleHttp\Psr7\stream_for($file);
+                $stream = \GuzzleHttp\Psr7\Utils::streamFor($file);
                 $this->requestBody = $stream;
                 return $this->execute($client);
             } else {

--- a/tests/Http/HttpTest.php
+++ b/tests/Http/HttpTest.php
@@ -148,7 +148,7 @@ class HttpTest extends TestCase
 
     public function testSendStream()
     {
-        $body = GuzzleHttp\Psr7\stream_for('stream');
+        $body = GuzzleHttp\Psr7\Utils::streamFor('stream');
         $request = $this->getRequest->attachBody($body);
         $this->assertInstanceOf(GraphRequest::class, $request);
 

--- a/tests/Http/StreamTest.php
+++ b/tests/Http/StreamTest.php
@@ -20,7 +20,7 @@ class StreamTest extends TestCase
         $this->root = vfsStream::setup('testDir');
 
         $this->body = json_encode(array('body' => 'content'));
-        $stream = GuzzleHttp\Psr7\stream_for('content');
+        $stream = GuzzleHttp\Psr7\Utils::streamFor('content');
 
         $mock = new GuzzleHttp\Handler\MockHandler([
             new GuzzleHttp\Psr7\Response(200, ['foo' => 'bar'], $this->body),


### PR DESCRIPTION
Fixes #543

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/544)