### PR TITLE
Add guzzle's psr7 lib as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 	"require": {
 		"php": "^8.0 || ^7.3",
 		"guzzlehttp/guzzle": "^6.0 || ^7.0",
+		"guzzlehttp/psr7": "^1.2",
 		"ext-json": "*"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"require": {
 		"php": "^8.0 || ^7.3",
 		"guzzlehttp/guzzle": "^6.0 || ^7.0",
-		"guzzlehttp/psr7": "^1.2",
+		"guzzlehttp/psr7": "^2.0",
 		"ext-json": "*"
 	},
 	"require-dev": {


### PR DESCRIPTION
The SDK uses the `guzzlehttp/psr7` package's `stream_for()` method directly but has been relying on the version installed by default with the Guzzle HTTP client library (`guzzlehttp/guzzle`).

`guzzlehttp/guzzle`'s [latest minor upgrade](https://github.com/guzzle/guzzle/blob/master/CHANGELOG.md#730---2021-03-23) supports `guzzlehttp/psr7` 2.0 by default which "breaks" the `stream_for()` functionality by making it a util method accessed via a static context.

Customers who install the current latest version of the SDK will get `guzzlehttp/psr7` 2.0 by default and will have broken functionality in the SDK which relies on the `guzzlehttp/psr7` 1.x `stream_for()`.

This PR explicity defines `guzzlehttp/psr7` as a dependency since we use it directly e.g. [here](https://github.com/microsoftgraph/msgraph-sdk-php/blob/dev/src/Model/PasswordCredential.php#L39)
It also downgrades `guzzlehttp/psr7`'s version to `^1.2` which is the minimum supported PSR-7 version by `guzzlehttp/guzzle` `7.x`  to temporarily fix the broken functionality.

Related to https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/555

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/548)