### PR TITLE
Downgrade guzzlehttp/psr7 to 1.0 and revert #544

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"require": {
 		"php": "^8.0 || ^7.3",
 		"guzzlehttp/guzzle": "^6.0 || ^7.0",
-		"guzzlehttp/psr7": "^2.0",
+		"guzzlehttp/psr7": "^1.0",
 		"ext-json": "*"
 	},
 	"require-dev": {

--- a/src/Core/GraphConstants.php
+++ b/src/Core/GraphConstants.php
@@ -23,7 +23,7 @@ final class GraphConstants
     const REST_ENDPOINT = "https://graph.microsoft.com/";
 
     // Define HTTP request constants
-    const SDK_VERSION = "1.35.0";
+    const SDK_VERSION = "1.35.1";
 
     // Define error constants
     const MAX_PAGE_SIZE = 999;

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -466,7 +466,7 @@ class GraphRequest
         try {
             if (file_exists($path) && is_readable($path)) {
                 $file = fopen($path, 'r');
-                $stream = \GuzzleHttp\Psr7\Utils::streamFor($file);
+                $stream = \GuzzleHttp\Psr7\stream_for($file);
                 $this->requestBody = $stream;
                 return $this->execute($client);
             } else {

--- a/tests/Http/HttpTest.php
+++ b/tests/Http/HttpTest.php
@@ -148,7 +148,7 @@ class HttpTest extends TestCase
 
     public function testSendStream()
     {
-        $body = GuzzleHttp\Psr7\Utils::streamFor('stream');
+        $body = GuzzleHttp\Psr7\stream_for('stream');
         $request = $this->getRequest->attachBody($body);
         $this->assertInstanceOf(GraphRequest::class, $request);
 

--- a/tests/Http/StreamTest.php
+++ b/tests/Http/StreamTest.php
@@ -20,7 +20,7 @@ class StreamTest extends TestCase
         $this->root = vfsStream::setup('testDir');
 
         $this->body = json_encode(array('body' => 'content'));
-        $stream = GuzzleHttp\Psr7\Utils::streamFor('content');
+        $stream = GuzzleHttp\Psr7\stream_for('content');
 
         $mock = new GuzzleHttp\Handler\MockHandler([
             new GuzzleHttp\Psr7\Response(200, ['foo' => 'bar'], $this->body),


### PR DESCRIPTION
Adding `guzzlehttp/psr7` as a hard dependency and specifying a minimum of `2.0` creates a breaking change for customers.

Correct approach should have been to set the dependency to minimum supported by `guzzlehttp/guzzle: ^6.0`

`guzzlehttp/guzzle: ^7.0` still works with `guzzlehttp/psr7: ^1.7`

Reverts #544 and #548.

Fixes #560 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/561)