### PR TITLE
Removes guzzlehttp/psr7 as direct dependency & reverts to Utils::streamFor()

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can install the PHP SDK with Composer, either run `composer require microsof
 ```
 {
     "require": {
-        "microsoft/microsoft-graph": "^1.35.1"
+        "microsoft/microsoft-graph": "^1.36.0"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
 	"require": {
 		"php": "^8.0 || ^7.3",
 		"guzzlehttp/guzzle": "^6.0 || ^7.0",
-		"guzzlehttp/psr7": "^1.0",
 		"ext-json": "*"
 	},
 	"require-dev": {

--- a/src/Core/GraphConstants.php
+++ b/src/Core/GraphConstants.php
@@ -23,7 +23,7 @@ final class GraphConstants
     const REST_ENDPOINT = "https://graph.microsoft.com/";
 
     // Define HTTP request constants
-    const SDK_VERSION = "1.35.1";
+    const SDK_VERSION = "1.36.0";
 
     // Define error constants
     const MAX_PAGE_SIZE = 999;

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -466,7 +466,7 @@ class GraphRequest
         try {
             if (file_exists($path) && is_readable($path)) {
                 $file = fopen($path, 'r');
-                $stream = \GuzzleHttp\Psr7\stream_for($file);
+                $stream = \GuzzleHttp\Psr7\Utils::streamFor($file);
                 $this->requestBody = $stream;
                 return $this->execute($client);
             } else {

--- a/tests/Http/HttpTest.php
+++ b/tests/Http/HttpTest.php
@@ -148,7 +148,7 @@ class HttpTest extends TestCase
 
     public function testSendStream()
     {
-        $body = GuzzleHttp\Psr7\stream_for('stream');
+        $body = GuzzleHttp\Psr7\Utils::streamFor('stream');
         $request = $this->getRequest->attachBody($body);
         $this->assertInstanceOf(GraphRequest::class, $request);
 

--- a/tests/Http/StreamTest.php
+++ b/tests/Http/StreamTest.php
@@ -20,7 +20,7 @@ class StreamTest extends TestCase
         $this->root = vfsStream::setup('testDir');
 
         $this->body = json_encode(array('body' => 'content'));
-        $stream = GuzzleHttp\Psr7\stream_for('content');
+        $stream = GuzzleHttp\Psr7\Utils::streamFor('content');
 
         $mock = new GuzzleHttp\Handler\MockHandler([
             new GuzzleHttp\Psr7\Response(200, ['foo' => 'bar'], $this->body),


### PR DESCRIPTION
Further discussion with the team led to a conclusion to rely on guzzlehttp/guzzle to determine the version of guzzlehttp/psr7 to be installed with the package as has been the case previously.

This PR:
- removes direct dependency on guzzlehttp/psr7
- removes deprecated `\GuzzleHttp\Psr7\stream_for()` in favour of `\GuzzleHttp\Psr7\Utils::streamFor()` that is also available in guzzlehttp/psr7 >= 1.7. The models will be updated once https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/569 is merged & new run is triggered.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/574)