### PR TITLE
Update preview sdk version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can install the PHP SDK with Composer, either run `composer require microsof
 ```
 {
     "require": {
-        "microsoft/microsoft-graph": "^2.0.0-preview.1"
+        "microsoft/microsoft-graph": "^2.0.0-RC1"
     }
 }
 ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,7 +24,7 @@ Version 2 removes our Beta models from the current package to allow us to adhere
 from merging breaking Beta model updates weekly. Users of the Beta models can now use the Beta SDK via `composer require microsoft/microsoft-graph-beta` or requiring it in your `composer.json`:
 ```php
  "require": {
-    "microsoft/microsoft-graph-beta": "^2.0.0-preview"
+    "microsoft/microsoft-graph-beta": "^2.0.0-RC1"
 }
 ```
 Moving forward, the current package (`microsoft/microsoft-graph`) will only contain v1 models that match the [Microsoft Graph v1 API metadata](https://graph.microsoft.com/v1.0/$metadata)

--- a/src/GraphConstants.php
+++ b/src/GraphConstants.php
@@ -19,5 +19,5 @@ namespace Microsoft\Graph;
 final class GraphConstants
 {
     const API_VERSION = "v1.0";
-    const SDK_VERSION = "2.0.0-preview.1";
+    const SDK_VERSION = "2.0.0-RC1";
 }


### PR DESCRIPTION
Composer considers the `preview` suffix to be an INVALID version constraint. The `RC` suffix convention works as expected.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/667)