### PR TITLE
Add minimum-stability constraint to installation snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,21 @@
 [![Latest Stable Version](https://poser.pugx.org/microsoft/microsoft-graph/version)](https://packagist.org/packages/microsoft/microsoft-graph)
 
 ## Install the SDK
-You can install the PHP SDK with Composer, either run `composer require microsoft/microsoft-graph`, or edit your `composer.json` file:
+You can install the PHP SDK with Composer by editing your `composer.json` file:
+```
+{
+    "minimum-stability": "RC",
+    "require": {
+        "microsoft/microsoft-graph": "^2.0.0-RC1",
+    }
+}
+```
+OR
 ```
 {
     "require": {
-        "microsoft/microsoft-graph": "^2.0.0-RC1"
+        "microsoft/microsoft-graph": "^2.0.0-RC1",
+        "microsoft/microsoft-graph-core": "@RC"
     }
 }
 ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,9 +21,17 @@ The following breaking changes were introduced in v2.0.0 with more detailed upgr
 In v1.x, we support models that match the [Microsoft Graph Beta API metadata](https://graph.microsoft.com/beta/$metadata).
 
 Version 2 removes our Beta models from the current package to allow us to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) by preventing us
-from merging breaking Beta model updates weekly. Users of the Beta models can now use the Beta SDK via `composer require microsoft/microsoft-graph-beta` or requiring it in your `composer.json`:
+from merging breaking Beta model updates weekly. Users of the Beta models can now use the Beta SDK by requiring it in your `composer.json`:
 ```php
  "require": {
+    "microsoft/microsoft-graph-beta": "^2.0.0-RC1",
+    "microsoft/microsoft-graph-core": "@RC"
+}
+```
+OR
+```php
+"minimum-stability": "RC"
+"require": {
     "microsoft/microsoft-graph-beta": "^2.0.0-RC1"
 }
 ```


### PR DESCRIPTION
Adding minimum-stability allows composer to install an `RC` version of `microsoft/microsoft-graph-core` which is a dependency of beta.

This only applies while `microsoft/microsoft-graph-core` is in `RC`. Once stable, a customer can require beta without minimum-stability constraints

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/676)