### PR TITLE
Add recursive serialization to entities

### DIFF
--- a/src/Beta/Microsoft/Graph/Model/Entity.php
+++ b/src/Beta/Microsoft/Graph/Model/Entity.php
@@ -124,6 +124,8 @@ class Entity implements \JsonSerializable
                 $serializableProperties[$property] = $val->format(\DateTime::RFC3339);
             } else if (is_a($val, "\Microsoft\Graph\Core\Enum")) {
                 $serializableProperties[$property] = $val->value();
+            } else if (is_a($val, "\Entity")) {
+                $serializableProperties[$property] = $val->jsonSerialize();
             }
         }
         return $serializableProperties;

--- a/src/Model/Entity.php
+++ b/src/Model/Entity.php
@@ -124,6 +124,8 @@ class Entity implements \JsonSerializable
                 $serializableProperties[$property] = $val->format(\DateTime::RFC3339);
             } else if (is_a($val, "\Microsoft\Graph\Core\Enum")) {
                 $serializableProperties[$property] = $val->value();
+            } else if (is_a($val, "\Entity")) {
+                $serializableProperties[$property] = $val->jsonSerialize();
             }
         }
         return $serializableProperties;


### PR DESCRIPTION
When calling `jsonSerialize()` on entities if the properties of that entity contain any other entities it does not serialize them properly. This pull request adds in the recursive serialization for entities.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/694)