### PR TITLE
(v2 Preview) Bump Graph-Core dependency & Update Upgrade Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can install the PHP SDK with Composer by editing your `composer.json` file:
 {
     "minimum-stability": "RC",
     "require": {
-        "microsoft/microsoft-graph": "^2.0.0-RC2",
+        "microsoft/microsoft-graph": "^2.0.0-RC3",
     }
 }
 ```
@@ -17,7 +17,7 @@ OR
 ```
 {
     "require": {
-        "microsoft/microsoft-graph": "^2.0.0-RC2",
+        "microsoft/microsoft-graph": "^2.0.0-RC3",
         "microsoft/microsoft-graph-core": "@RC"
     }
 }

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,23 @@
 
 This guide highlights breaking changes, bug fixes and new features introduced during major upgrades.
 
+# Upgrading from 2.0-RC2 to 2.0-RC3
+
+# Breaking Changes
+## `GraphClientException` & `GraphServerException`'s `getRawResponseBody()` returns a `StreamInterface` instead of `array`
+The SDK currently throws a `GraphClientException` 4xx responses and a `GraphServiceException` for 5xx responses from the Graph API.
+The raw payload that accompanied the 4xx/5xx status code can be retrieved by calling `getRawResponseBody()` on the exception object.
+
+This change returns a `StreamInterface` instead of an array to accommodate HTML/string response bodies.
+
+To get the response payload as an Error object, use `getError()`. To get the raw string you can now use `getResponseBodyAsString()` and to get
+the json-decoded response use `getResponseBodyJson()`.
+
+# Bug Fixes
+Adding headers to a `GraphRequest` now allows you to overwrite the default headers e.g. Content-Type. Previously,
+any new header values would be appended to the default value.
+
+
 # Upgrading from 1.x to 2.0
 - [Breaking Changes](#breaking-changes)
 - [Bug Fixes](#bug-fixes)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,10 +2,13 @@
 
 This guide highlights breaking changes, bug fixes and new features introduced during major upgrades.
 
+- [2.0-RC2 ... 2.0-RC3](#upgrading-from-20-rc2-to-20-rc3)
+- [1.x ... 2.0](#upgrading-from-1x-to-20)
+
 # Upgrading from 2.0-RC2 to 2.0-RC3
 
-# Breaking Changes
-## `GraphClientException` & `GraphServerException`'s `getRawResponseBody()` returns a `StreamInterface` instead of `array`
+## 2.0-RC3 Breaking Changes
+### `GraphClientException` & `GraphServerException`'s `getRawResponseBody()` returns a `StreamInterface` instead of `array`
 The SDK currently throws a `GraphClientException` 4xx responses and a `GraphServiceException` for 5xx responses from the Graph API.
 The raw payload that accompanied the 4xx/5xx status code can be retrieved by calling `getRawResponseBody()` on the exception object.
 
@@ -14,17 +17,17 @@ This change returns a `StreamInterface` instead of an array to accommodate HTML/
 To get the response payload as an Error object, use `getError()`. To get the raw string you can now use `getResponseBodyAsString()` and to get
 the json-decoded response use `getResponseBodyJson()`.
 
-# Bug Fixes
+## 2.0-RC3 Bug Fixes
 Adding headers to a `GraphRequest` now allows you to overwrite the default headers e.g. Content-Type. Previously,
 any new header values would be appended to the default value.
 
 
 # Upgrading from 1.x to 2.0
-- [Breaking Changes](#breaking-changes)
-- [Bug Fixes](#bug-fixes)
-- [New Features](#new-features)
+- [Breaking Changes](#20-breaking-changes)
+- [Bug Fixes](#20-bug-fixes)
+- [New Features](#20-new-features)
 
-# Breaking Changes
+# 2.0 Breaking Changes
 The following breaking changes were introduced in v2.0.0 with more detailed upgrade steps in the following section:
 - [Moved Beta models to the Microsoft Graph Beta SDK](#moved-beta-models-to-the-microsoft-graph-beta-sdkhttpspackagistorgpackagesmicrosoftmicrosoft-graph-beta).
 - [Changes to the Graph client construction and configuration experience](#changes-to-graph-client-instantiation-and-configuration).
@@ -208,7 +211,7 @@ various methods. Where there has been a breaking change, they have been outlined
 ## Changes to the base Enum class
 `has()` and `toArray()` have been made static methods.
 
-# Bug Fixes
+# 2.0 Bug Fixes
 Model getters expected to return a collection of entities now work as expected e.g. getting meeting attendees using v1.x of the SDK
 would return a single attendee object instead of a list of attendees causing various PHP warnings and errors:
 ```php
@@ -229,7 +232,7 @@ if ($attendees) {
 ```
 Version 2, fixes such getters to return the expected list of entities (`MeetingParticipantInfo[]`).
 
-# New Features
+# 2.0 New Features
 
 ### Introducing the `PageIterator`
 The `PageIterator` allows you to asynchronously page through a collection response from the Graph API while processing each item in the collection

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": "^8.0 || ^7.3",
-		"microsoft/microsoft-graph-core": "2.0.0-RC1",
+		"microsoft/microsoft-graph-core": "2.0.0-RC3",
 		"ext-json": "*"
 	},
 	"require-dev": {

--- a/src/GraphConstants.php
+++ b/src/GraphConstants.php
@@ -19,5 +19,5 @@ namespace Microsoft\Graph;
 final class GraphConstants
 {
     const API_VERSION = "v1.0";
-    const SDK_VERSION = "2.0.0-RC2";
+    const SDK_VERSION = "2.0.0-RC3";
 }


### PR DESCRIPTION
A breaking bug fix on Core (https://github.com/microsoftgraph/msgraph-sdk-php-core/pull/55) warrants a bump in the Graph-core dependency.
This PR also updates the upgrade guide with these changes

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/778)