### PR TITLE
Configure Guzzle for HTTP 2 if platform supports it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,9 @@
 		"php": "^8.0 || ^7.3",
 		"guzzlehttp/guzzle": "^6.0 || ^7.0",
 		"ext-json": "*",
-		"psr/http-message": "^1.0"
-	},
+		"psr/http-message": "^1.0",
+      	"ext-curl": "*"
+    },
 	"require-dev": {
 		"phpunit/phpunit": "^8.0 || ^9.0",
 		"mikey179/vfsstream": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
 		"php": "^8.0 || ^7.3",
 		"guzzlehttp/guzzle": "^6.0 || ^7.0",
 		"ext-json": "*",
-		"psr/http-message": "^1.0",
-      	"ext-curl": "*"
+		"psr/http-message": "^1.0"
     },
 	"require-dev": {
 		"phpunit/phpunit": "^8.0 || ^9.0",

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -545,7 +545,7 @@ class GraphRequest
             $clientSettings['verify'] = $this->proxyVerifySSL;
             $clientSettings['proxy'] = $this->proxyPort;
         }
-        if (curl_version()["features"] & CURL_VERSION_HTTP2 !== 0) {
+        if (extension_loaded('curl') && (curl_version()["features"] & CURL_VERSION_HTTP2 !== 0)) {
             // Enable HTTP/2 if curl lib contains it
             $clientSettings['version'] = '2';
         }

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -546,7 +546,7 @@ class GraphRequest
             $clientSettings['proxy'] = $this->proxyPort;
         }
         if (extension_loaded('curl') && (curl_version()["features"] & CURL_VERSION_HTTP2 !== 0)) {
-            // Enable HTTP/2 if curl lib contains it
+            // Enable HTTP/2 if curl lib exists and supports it
             $clientSettings['version'] = '2';
         }
         return new Client($clientSettings);

--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -484,13 +484,12 @@ class GraphRequest
     */
     private function _getDefaultHeaders()
     {
-        $headers = [
+        return [
             'Host' => $this->baseUrl,
             'Content-Type' => 'application/json',
             'SdkVersion' => 'Graph-php-' . GraphConstants::SDK_VERSION,
             'Authorization' => 'Bearer ' . $this->accessToken
         ];
-        return $headers;
     }
 
     /**
@@ -546,8 +545,10 @@ class GraphRequest
             $clientSettings['verify'] = $this->proxyVerifySSL;
             $clientSettings['proxy'] = $this->proxyPort;
         }
-        $client = new Client($clientSettings);
-
-        return $client;
+        if (curl_version()["features"] & CURL_VERSION_HTTP2 !== 0) {
+            // Enable HTTP/2 if curl lib contains it
+            $clientSettings['version'] = '2';
+        }
+        return new Client($clientSettings);
     }
 }


### PR DESCRIPTION
Guzzle relies on `curl` to make HTTP 2 requests.

This PR checks that the curl version on the platform supports HTTP/2 before enabling the option. Enabling version 2 on Guzzle while the underlying curl lib doesn't support it has been reported to [throw errors](https://github.com/guzzle/guzzle/issues/1249#issue-105141274). The platform checks prevent this.

**Why this change now?**
For now, since Graph supports HTTP/1.1 only, requests will still work since client and server will negotiate and result to HTTP 1.1
Once Graph supports HTTP 2, requests will default to HTTP 2

closes #765 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/818)