### PR TITLE
Change GraphResponse raw body PHPDoc type to StreamInterface

### DIFF
--- a/src/Http/GraphResponse.php
+++ b/src/Http/GraphResponse.php
@@ -17,8 +17,7 @@
 
 namespace Microsoft\Graph\Http;
 
-use Microsoft\Graph\Exception\GraphException;
-use Microsoft\Graph\Core\GraphConstants;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Class GraphResponse
@@ -33,7 +32,7 @@ class GraphResponse
     /**
     * The body of the response
     *
-    * @var string
+    * @var StreamInterface|null
     */
     private $_body;
     /**
@@ -60,7 +59,7 @@ class GraphResponse
     * Creates a new Graph HTTP response entity
     *
     * @param object $request        The request
-    * @param string $body           The body of the response
+    * @param StreamInterface|null $body           The body of the response
     * @param string $httpStatusCode The returned status code
     * @param array  $headers        The returned headers
     */
@@ -100,7 +99,7 @@ class GraphResponse
     /**
     * Get the undecoded body of the HTTP response
     *
-    * @return string|null The undecoded body
+    * @return StreamInterface|null The undecoded body
     */
     public function getRawBody()
     {

--- a/tests/Http/GraphResponseTest.php
+++ b/tests/Http/GraphResponseTest.php
@@ -106,6 +106,8 @@ class GraphResponseTest extends TestCase
         $response = $this->request->execute($this->client);
 
         $body = $response->getRawBody();
+        $this->assertInstanceOf(\Psr\Http\Message\StreamInterface::class, $body);
+        $this->assertIsNotString($body);
         $this->assertEquals(json_encode($this->responseBody), $body);
     }
 


### PR DESCRIPTION
We have previously used the wrong PHPDoc type leading to confusion as to what type `getRawBody()` returns e.g. https://github.com/microsoftgraph/msgraph-sdk-php/issues/187#issuecomment-1079140313 where customer correctly expects to handle the returned type as `string` yet the returned type is a `StreamInterface`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/844)