### PR TITLE
Update PHPDocs to correct value in SchedulingGroup Model

### DIFF
--- a/src/Model/SchedulingGroup.php
+++ b/src/Model/SchedulingGroup.php
@@ -86,7 +86,7 @@ class SchedulingGroup extends ChangeTrackedEntity
     * Gets the userIds
     * The list of user IDs that are a member of the schedulingGroup. Required.
     *
-    * @return string|null The userIds
+    * @return array|null The userIds
     */
     public function getUserIds()
     {
@@ -101,7 +101,7 @@ class SchedulingGroup extends ChangeTrackedEntity
     * Sets the userIds
     * The list of user IDs that are a member of the schedulingGroup. Required.
     *
-    * @param string $val The userIds
+    * @param array $val The userIds
     *
     * @return SchedulingGroup
     */


### PR DESCRIPTION
Functions getUserIds and setUserIds are getting and setting arrays, but the PHPDocs type suggests it's of type string. This causes IDE (such as PHPStorm) to throws error on code analysis.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/1018)