### PR TITLE
Add support for php 8.2

### DIFF
--- a/src/Http/GraphResponse.php
+++ b/src/Http/GraphResponse.php
@@ -54,6 +54,8 @@ class GraphResponse
     * @var string
     */
     private $_httpStatusCode;
+    
+    private $_request;
 
     /**
     * Creates a new Graph HTTP response entity


### PR DESCRIPTION
In php 8.2 is deprecated define dynamic properties.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/1103)