### PR TITLE
Fix HTTP/2 feature check

### DIFF
--- a/src/Http/GraphRequest.php
+++ b/src/Http/GraphRequest.php
@@ -545,7 +545,7 @@ class GraphRequest
             $clientSettings['verify'] = $this->proxyVerifySSL;
             $clientSettings['proxy'] = $this->proxyPort;
         }
-        if (extension_loaded('curl') && defined('CURL_VERSION_HTTP2') && (curl_version()["features"] & CURL_VERSION_HTTP2 !== 0)) {
+        if (extension_loaded('curl') && defined('CURL_VERSION_HTTP2') && (curl_version()["features"] & CURL_VERSION_HTTP2) == CURL_VERSION_HTTP2) {
 
             // Enable HTTP/2 if curl lib exists and supports it
             $clientSettings['version'] = '2';


### PR DESCRIPTION
related to https://github.com/microsoftgraph/msgraph-sdk-php/issues/854

Before enabling HTTP/2, we check if the feature is supported by curl. [`curl_version()["features"]`](https://www.php.net/manual/en/function.curl-version.php) provides a bitmask comprised of the supported features.

We perform a bitwise `&` with the `CURL_VERSION_HTTP2` flag to check if it's enabled.

Previous implementation had 2 bugs:
- We should be comparing the result of the bitwise operation with the `CURL_VERSION_HTTP2` flag
- Without parentheses, `curl_version()["features"] & CURL_VERSION_HTTP2 !== 0` first evaluates `CURL_VERSION_HTTP2 !== 0` then performs the bitwise `&` always returning `1` hence HTTP/2 would always be enabled even if the curl library doesn't enable it.

This PR fixes this.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/1120)