### PR TITLE
Replace deprecated unwrap method in promises namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 	"require-dev": {
 		"phpunit/phpunit": "^8.0 || ^9.0",
 		"mikey179/vfsstream": "^1.2",
-		"phpstan/phpstan": "^0.12.90 || ^1.0.0"
+		"phpstan/phpstan": "^0.12.90 || ^1.0.0",
+		"guzzlehttp/promises": "^1.0 || ^2.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/tests/Http/GraphRequestTest.php
+++ b/tests/Http/GraphRequestTest.php
@@ -1,4 +1,6 @@
 <?php
+
+use GuzzleHttp\Promise\Utils;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Microsoft\Graph\Core\GraphConstants;
@@ -173,7 +175,7 @@ class GraphRequestTest extends TestCase
         $promise2 = $this->requests[2]
                           ->executeAsync($this->client);
 
-        $response = \GuzzleHttp\Promise\unwrap(array($promise));
+        $response = Utils::unwrap(array($promise));
         foreach ($response as $responseItem) {
             $this->assertInstanceOf(Microsoft\Graph\Http\GraphResponse::class, $responseItem);
         }


### PR DESCRIPTION
Latest Guzzle client now supports Guzzle Promises v2 which deprecates calling `unwrap()` under the `GuzzleHttp\Promise` namespace in favour of `unwrap()` in the `Utils` namespace.

Adds guzzlehttp/promises version as a dev-dependency since we use it directly in the tests to prevent future deprecation failures.

This is blocking this week's generation -https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=115854&view=logs&j=29aed401-fc9b-57ac-1f64-2375ad5c4825&t=c358aceb-1691-5ab4-29cb-fd16fd0dd51f&l=175

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-php/pull/1248)