### PR TITLE
Update regex in tagging workflow to push RC versions correctly

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Get SDK version and set environment variable
       run: |
-        SDK_VERSION=$(grep 'SDK_VERSION' src/GraphConstants.php |  grep -oE '[0-9]+\.[0-9]+\.([0-9]+|[0-9]+-[a-z]+)')
+        SDK_VERSION=$(grep 'SDK_VERSION' src/GraphConstants.php |  grep -oE '[0-9]+\.[0-9]+\.[0-9A-Za-z.\-]+')
         echo "SDK_VERSION=$SDK_VERSION" >> $GITHUB_ENV
 
     - name: Create and publish tag


### PR DESCRIPTION
Fixes issue where workflow pushed a 2.0.0 tag mistakenly - https://packagist.org/packages/microsoft/microsoft-graph
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-php/pull/1326)