### PR TITLE
Add token reuse documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ $tokenRequestContext = new AuthorizationCodeContext(
 ```
 Note that your application will need to handle redirecting the user to the Microsoft Identity login page to get the `authorization_code` that's passed into the `AuthorizationCodeContext`.
 [See](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow) for more on the `authorization_code` grant flow.
+To prevent signing in your user before each request, see section on [access token management](docs/Examples.md#access-token-management)
 
 
 ### Initialize a GraphServiceClient
@@ -75,6 +76,8 @@ $graphServiceClient = new GraphServiceClient($tokenRequestContext);
 $scopes = ['User.Read', 'Mail.ReadWrite'];
 $graphServiceClient = new GraphServiceClient($tokenRequestContext, $scopes);
 ```
+
+To initialise the `GraphServiceClient` with an already acquired access token, see section on [access token management](docs/Examples.md#access-token-management).
 
 For more on Graph client configuration, see [more examples](docs/Examples.md#creating-a-graph-client)
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $tokenRequestContext = new AuthorizationCodeContext(
 ```
 Note that your application will need to handle redirecting the user to the Microsoft Identity login page to get the `authorization_code` that's passed into the `AuthorizationCodeContext`.
 [See](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow) for more on the `authorization_code` grant flow.
-To prevent signing in your user before each request, see section on [access token management](docs/Examples.md#access-token-management)
+To keep your user signed in across multiple requests within a session, see section on [access token management](docs/Examples.md#access-token-management)
 
 
 ### Initialize a GraphServiceClient
@@ -77,7 +77,7 @@ $scopes = ['User.Read', 'Mail.ReadWrite'];
 $graphServiceClient = new GraphServiceClient($tokenRequestContext, $scopes);
 ```
 
-To initialise the `GraphServiceClient` with an already acquired access token, see section on [access token management](docs/Examples.md#access-token-management).
+To initialize the `GraphServiceClient` with an already acquired access token or to retrieve the access token that the SDK fetches on your behalf, see section on [access token management](docs/Examples.md#access-token-management).
 
 For more on Graph client configuration, see [more examples](docs/Examples.md#creating-a-graph-client)
 

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -92,14 +92,20 @@ Using the `TokenRequestContext`, an instance of the `GraphServiceClient` request
 The tokens are stored by default in an in-memory cache so that future requests using the same instance of the `GraphServiceClient` can re-use the previously acquired tokens.
 
 For scenarios where an application requires a signed-in user, retaining the same
-instance of the `GraphServiceClient` across multiple requests/within a user session is not feasible.
+instance of the `GraphServiceClient` across multiple requests to your application for the same user's session is not feasible. This section outlines
+how your application can retrieve access tokens from the SDK and pass already acquired access tokens to the SDK for future requests without the user signing in for each request.
 
 ### Retrieving the access token from the SDK
 
 The SDK provides a mechanism to expose the access token and refresh token that it acquires to your application for use in future requests. This would prevent the SDK from making a new
 token request with each `GraphServiceClient` your application instantiates. It also allows your application to prevent its users from signing in with each request within a session.
 
-To get the tokens acquired by the SDK, the built-in [`InMemoryAccessTokenCache`](https://github.com/microsoft/kiota-authentication-phpleague-php/blob/dev/src/Cache/InMemoryAccessTokenCache.php) can be passed to the `GraphServiceClient`. The cache will be populated with a PHPLeague [`AccessToken`](https://github.com/thephpleague/oauth2-client/blob/master/src/Token/AccessToken.php) object which carries both the `access_token`, its expiry and a `refresh_token` if available:
+By default a `GraphServiceClient` instance caches access tokens in a built-in [`InMemoryAccessTokenCache`](https://github.com/microsoft/kiota-authentication-phpleague-php/blob/dev/src/Cache/InMemoryAccessTokenCache.php). The cache will be populated with a PHPLeague [`AccessToken`](https://github.com/thephpleague/oauth2-client/blob/master/src/Token/AccessToken.php) object which carries both the `access_token`, its expiry and a `refresh_token` if available. When the `GraphServiceClient` instance is re-used for a request with the same user/application, the in-memory cache is checked for a valid token otherwise a new token request is made.
+
+However, to get the cached token that the SDK requests for a user/application you
+can initialise an `InMemoryAccessTokenCache` or pass a custom implementation of the [`AccessTokenCache`](https://github.com/microsoft/kiota-authentication-phpleague-php/blob/dev/src/Cache/AccessTokenCache.php) interface interface and pass it as a parameter when initialising the `GraphServiceClient`. The two approaches are outlined below:
+
+*Using an InMemoryAccessTokenCache instance*:
 
 ```php
 use Microsoft\Kiota\Authentication\Cache\InMemoryAccessTokenCache;
@@ -197,7 +203,8 @@ $graphServiceClient = GraphServiceClient::createWithAuthenticationProvider(
 
 ```
 
-To initialize the cache with multiple TokenRequestContext-AccessToken pairs, `withToken` can be used:
+For scenarios where your application may need to make requests for multiple users using the same `GraphServiceClient`, the `InMemoryAccessTokenCache` can
+be initialized with multiple TokenRequestContext-AccessToken pairs using `withToken`:
 ```php
 
 use Microsoft\Kiota\Authentication\Cache\InMemoryAccessTokenCache;

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -91,6 +91,10 @@ $graphServiceClient = GraphServiceClient::createWithRequestAdapter($requestAdapt
 Using the `TokenRequestContext`, an instance of the `GraphServiceClient` requests access tokens and refresh tokens.
 The tokens are stored by default in an in-memory cache so that future requests using the same instance of the `GraphServiceClient` can re-use the previously acquired tokens.
 
+The default in-memory cache is a map/dictionary with a unique key identifying a user/application with a tenant and a PHPLeague [`AccessToken`](https://github.com/thephpleague/oauth2-client/blob/master/src/Token/AccessToken.php) object as its value. The unique key ensures the right token for a user is retrieved from the cache. For `TokenRequestContexts` that do not require a signed in user (application permissions), the cache key will be **`{tenantId}-{clientId}`** and for those that require a signed in user (delegated permissions), the cache key will be
+**`{tenantId}-{clientId}-{userId}`**. The `AccessToken` object carries both the `access_token`, its expiry and a `refresh_token` if available.
+The in-memory cache lives as a PHP object within the your application's PHP process and is destroyed when the process terminates.
+
 For scenarios where an application requires a signed-in user, retaining the same
 instance of the `GraphServiceClient` across multiple requests to your application for the same user's session is not feasible. This section outlines
 how your application can retrieve access tokens from the SDK and pass already acquired access tokens to the SDK for future requests without the user signing in for each request.

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -87,6 +87,183 @@ $graphServiceClient = GraphServiceClient::createWithRequestAdapter($requestAdapt
 
 ```
 
+## Access token management
+Using the `TokenRequestContext`, an instance of the `GraphServiceClient` requests access tokens and refresh tokens.
+The tokens are stored by default in an in-memory cache so that future requests using the same instance of the `GraphServiceClient` can re-use the previously acquired tokens.
+
+For scenarios where an application requires a signed-in user, retaining the same
+instance of the `GraphServiceClient` across multiple requests/within a user session is not feasible.
+
+### Retrieving the access token from the SDK
+
+The SDK provides a mechanism to expose the access token and refresh token that it acquires to your application for use in future requests. This would prevent the SDK from making a new
+token request with each `GraphServiceClient` your application instantiates. It also allows your application to prevent its users from signing in with each request within a session.
+
+To get the tokens acquired by the SDK, the built-in [`InMemoryAccessTokenCache`](https://github.com/microsoft/kiota-authentication-phpleague-php/blob/dev/src/Cache/InMemoryAccessTokenCache.php) can be passed to the `GraphServiceClient`. The cache will be populated with a PHPLeague [`AccessToken`](https://github.com/thephpleague/oauth2-client/blob/master/src/Token/AccessToken.php) object which carries both the `access_token`, its expiry and a `refresh_token` if available:
+
+```php
+use Microsoft\Kiota\Authentication\Cache\InMemoryAccessTokenCache;
+use Microsoft\Graph\GraphServiceClient;
+use Microsoft\Graph\Core\Authentication\GraphPhpLeagueAccessTokenProvider;
+use Microsoft\Graph\Core\Authentication\GraphPhpLeagueAuthenticationProvider;
+use Microsoft\Kiota\Authentication\Oauth\AuthorizationCodeContext;
+
+$tokenRequestContext = new AuthorizationCodeContext(
+    'tenantId',
+    'clientId',
+    'clientSecret',
+    'authCode',
+    'redirectUri'
+);
+$scopes = ['User.Read', 'Mail.ReadWrite'];
+
+$inMemoryCache = new InMemoryAccessTokenCache();
+
+$graphServiceClient = GraphServiceClient::createWithAuthenticationProvider(
+    GraphPhpLeagueAuthenticationProvider::createWithAccessTokenProvider(
+        GraphPhpLeagueAccessTokenProvider::createWithCache(
+            $inMemoryCache,
+            $tokenRequestContext,
+            $scopes
+        )
+    )
+);
+
+$accessToken = $inMemoryCache->getTokenWithContext($tokenRequestContext);
+
+```
+
+*Using a custom AccessTokenCache implementation*:
+
+A custom [`AccessTokenCache`](https://github.com/microsoft/kiota-authentication-phpleague-php/blob/dev/src/Cache/AccessTokenCache.php) interface implementation can also be provided. After the request, the SDK persists the token in the
+custom cache via the `persistAccessToken()` method.
+
+By default, the SDK adds a unique cache key/identifier to a `TokenRequestContext` that uniquely identifies the tenant, client and user (if applicable).
+For `TokenRequestContexts` that do not require a signed in user (application permissions), the cache key will be
+**`{tenantId}-{clientId}`** and for those that require a signed in user (delegated permissions), the cache key will be
+**`{tenantId}-{clientId}-{userId}`**.
+
+To retrieve the access token persisted to your custom cache for a particular user's/application's `TokenRequestContext`:
+```php
+
+$accessToken = $customCache->getAccessToken($tokenRequestContext->getCacheKey());
+
+```
+
+### Initializing a GraphServiceClient with an access token
+
+For applications that already have built-in mechanisms to fetch and refresh access tokens, the SDK supports passing these tokens to a `GraphServiceClient` by initializing
+a client using an [`AccessTokenCache`](https://github.com/microsoft/kiota-authentication-phpleague-php/blob/dev/src/Cache/AccessTokenCache.php) interface implementation.
+
+The SDK provides a built-in implementation of this interface via an [`InMemoryAccessTokenCache`](https://github.com/microsoft/kiota-authentication-phpleague-php/blob/dev/src/Cache/InMemoryAccessTokenCache.php).
+
+This is also useful when re-using a previously retrieved access token for a signed-in user during a previous request.
+
+The SDK will check the cache for a valid token before considering requesting a new token. If the provided token is expired
+and a refresh token is present, the access token will be refreshed and persisted to the cache. If no refresh token is provided, the SDK requests attempts to retrieve a new access token and persists it to the cache. In cases where a signed in user is present, e.g. authorization_code OAuth flows, the new token request will most likely fail because no valid `authorization_code` will be present meaning the user has to sign in again.
+
+*Using the `InMemoryAccessTokenCache`*:
+The in-memory cache can be hydrated/initialised using the `TokenRequestContext` and a PHPLeague [`AccessToken`](https://github.com/thephpleague/oauth2-client/blob/master/src/Token/AccessToken.php) object for a user/application:
+
+```php
+
+use Microsoft\Kiota\Authentication\Cache\InMemoryAccessTokenCache;
+use Microsoft\Graph\GraphServiceClient;
+use Microsoft\Graph\Core\Authentication\GraphPhpLeagueAccessTokenProvider;
+use Microsoft\Graph\Core\Authentication\GraphPhpLeagueAuthenticationProvider;
+use League\OAuth2\Client\Token\AccessToken;
+
+
+$cache = new InMemoryAccessTokenCache(
+    $tokenRequestContext,
+    new AccessToken(
+        [
+            'access_token' => $accessToken,
+            'refresh_token' => $refreshToken,
+            'expires' => 1
+        ]
+    )
+);
+
+$graphServiceClient = GraphServiceClient::createWithAuthenticationProvider(
+    GraphPhpLeagueAuthenticationProvider::createWithAccessTokenProvider(
+        GraphPhpLeagueAccessTokenProvider::createWithCache(
+            $cache,
+            $tokenRequestContext,
+            $scopes
+        )
+    )
+);
+
+```
+
+To initialize the cache with multiple TokenRequestContext-AccessToken pairs, `withToken` can be used:
+```php
+
+use Microsoft\Kiota\Authentication\Cache\InMemoryAccessTokenCache;
+use Microsoft\Graph\GraphServiceClient;
+use Microsoft\Graph\Core\Authentication\GraphPhpLeagueAccessTokenProvider;
+use Microsoft\Graph\Core\Authentication\GraphPhpLeagueAuthenticationProvider;
+use League\OAuth2\Client\Token\AccessToken;
+
+$cache = (new InMemoryAccessTokenCache($tokenRequestContext, new AccessToken([
+    // ...
+])));
+
+$cache->withToken($tokenRequestContext2, new AccessToken([
+            // ...
+        ]))->withToken($tokenRequestContext, new AccessToken([
+            // ...
+        ]))->withToken($tokenRequestContext3, new AccessToken());
+
+
+$graphServiceClient = GraphServiceClient::createWithAuthenticationProvider(
+    GraphPhpLeagueAuthenticationProvider::createWithAccessTokenProvider(
+        GraphPhpLeagueAccessTokenProvider::createWithCache(
+            $cache,
+            $tokenRequestContext,
+            $scopes
+        )
+    )
+);
+
+```
+
+*Using a custom `AccessTokenCache` implementation`*:
+
+The SDK retrieves cached tokens using a cache key/identifier on the `TokenRequestContext`. The cache key
+on the `TokenRequestContext` is set using `setCacheKey()` which accepts an [`AccessToken`](https://github.com/thephpleague/oauth2-client/blob/master/src/Token/AccessToken.php) object.
+
+The `TokenRequestContext` uses the `AccessToken` to generate a unique identifier per user, client and tenant. For `TokenRequestContexts` that do not require a signed in user (application permissions), the cache key will be
+**`{tenantId}-{clientId}`** and for those that require a signed in user (delegated permissions), the cache key will be
+**`{tenantId}-{clientId}-{userId}`**.
+
+For this scenario, the custom AccessTokenCache will need to be initialized in a way that the cache key set on the
+`TokenRequestContext` aligns with the key the custom AccessTokenCache maps to the user/application's access token
+
+```php
+
+$tokenRequestContext->setCacheKey(new AccessToken([
+    'access_token' => $accessToken,
+    'refresh_token' => $refreshToken,
+    'expires' => ...
+]));
+
+// init custom cache with tokens that map to $tokenRequestContext->getCacheKey()
+
+// init graph client
+$graphServiceClient = GraphServiceClient::createWithAuthenticationProvider(
+    GraphPhpLeagueAuthenticationProvider::createWithAccessTokenProvider(
+        GraphPhpLeagueAccessTokenProvider::createWithCache(
+            $customCache,
+            $tokenRequestContext,
+            $scopes
+        )
+    )
+);
+
+```
+
 ## Get an item from the Graph
 This sample fetches the current signed-in user. Note that to use `\me` you need
 a delegated permission. Alternatively, using application permissions, you can request `/users/[userPrincipalName]`.


### PR DESCRIPTION
part of #1407 
part of https://github.com/microsoftgraph/msgraph-sdk-php/issues/1469

Developers have expressed feedback around
- Passing their own access tokens to their API clients
- Retrieving access tokens requested by a Kiota auth provider
Passing their own tokens/previously retrieved tokens to the API client is helpful in delegated scenarios because it prevents them from forcing their customers to log in multiple times for each request. Design doc is available.

Easier view: https://github.com/microsoftgraph/msgraph-sdk-php/blob/docs/token-reuse/docs/Examples.md#access-token-management
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-php/pull/1475)