### PR TITLE
Remove DOM diff export from shipped files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@
 phpdoc.dist.xml export-ignore
 phpstan.neon export-ignore
 phpunit.xml export-ignore
+/src/**/kiota-dom-export.txt export-ignore


### PR DESCRIPTION
Current DOM diff file is `~36MB` further increasing the lib size.
This removes it from the shipped archive uploaded to Packagist.

Testing:
Run `composer archive --format=zip` to get the files to be shipped & extract to validate.

Related https://github.com/microsoftgraph/msgraph-sdk-php/issues/1584
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-php/pull/1588)