### PR TITLE
fix: Wrong token cache test assertion

### DIFF
--- a/tests/GraphServiceClientTest.php
+++ b/tests/GraphServiceClientTest.php
@@ -100,6 +100,7 @@ class GraphServiceClientTest extends TestCase
 
         // cache is populated
         $this->assertInstanceOf(AccessToken::class, $customCache->getTokenWithContext($tokenRequestContext));
+        $this->assertEquals($this->testJWT, $customCache->getTokenWithContext($tokenRequestContext)->getToken());
 
         // hydrate another cache for follow-up request
         $newCache = new InMemoryAccessTokenCache($tokenRequestContext, $customCache->getTokenWithContext($tokenRequestContext));
@@ -119,6 +120,6 @@ class GraphServiceClientTest extends TestCase
 
         $me = $client->me()->get()->wait();
         // cache is populated
-        $this->assertInstanceOf(AccessToken::class, $customCache->getTokenWithContext($tokenRequestContext));
+        $this->assertInstanceOf(AccessToken::class, $newCache->getTokenWithContext($tokenRequestContext));
     }
 }


### PR DESCRIPTION
Fixes wrong assertion in token caching test where should be checking that the new cache contains an access token.

Unblocks generation PRs https://github.com/microsoftgraph/msgraph-sdk-php/pull/1620
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-php/pull/1621)