### PR TITLE
docs: add PHP 8.2 minimum version requirement and upgrade guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 [![PHP Version Require](http://poser.pugx.org/microsoft/microsoft-graph/require/php)](https://packagist.org/packages/microsoft/microsoft-graph)
 
 ## Install the SDK
+
+### Prerequisites
+- PHP 8.2 or later (see [PHP supported versions](https://www.php.net/supported-versions.php))
+
 You can install the PHP SDK with Composer by editing your `composer.json` file:
 ```jsonc
 {

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,25 @@
 This guide highlights breaking changes, bug fixes and new features introduced during major upgrades.
 
 
+# Upcoming Breaking Change: Minimum PHP version raised to 8.2
+
+The SDK now requires **PHP 8.2 or later**. Support for PHP 7.4, 8.0, and 8.1 has been removed.
+
+## Why
+
+PHP 7.4 (EOL Nov 2022), PHP 8.0 (EOL Nov 2023), and PHP 8.1 (EOL Dec 2025) no longer receive security updates from the PHP project. Continuing to support them prevented us from updating dependencies that have already dropped these versions, introducing potential security vulnerabilities.
+
+## What to do
+
+- Run `php -v` to check your current PHP version.
+- If you are on PHP 7.4, 8.0, or 8.1, upgrade to PHP 8.2 or later before updating the SDK.
+- No code changes are required — only the PHP runtime version needs to be updated.
+
+**Supported PHP versions:** 8.2, 8.3, 8.4
+
+See https://www.php.net/supported-versions.php for PHP's official support lifecycle.
+
+
 # Upgrading to 2.0.0
 - [New Features](#new-features)
 - [Breaking Changes](#breaking-changes)


### PR DESCRIPTION
## Summary

Adds documentation for the upcoming breaking change that drops PHP 7.4, 8.0, and 8.1 support, requiring PHP 8.2 or later.

### Changes
- **README.md**: Added Prerequisites section noting PHP 8.2+ requirement
- **UPGRADING.md**: Added breaking change section with EOL dates and migration steps

### Context
PHP 7.4 (EOL Nov 2022), 8.0 (EOL Nov 2023), and 8.1 (EOL Dec 2025) no longer receive security updates. The corresponding code change is in [microsoftgraph/msgraph-sdk-php-core#224](https://github.com/microsoftgraph/msgraph-sdk-php-core/pull/224).

cc @Treicysg
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-php/pull/1767)