### PR TITLE
Fix!: drop PHP 7.4–8.1 support to address insecure dependencies

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
     steps:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
 		}
 	],
 	"require": {
-		"php": "^8.0 || ^7.4",
+		"php": "^8.2",
 		"microsoft/microsoft-graph-core": "^2.2.1"
     },
 	"require-dev": {
-		"phpunit/phpunit": "^8.0 || ^9.0",
-		"phpstan/phpstan": "^0.12.90 || ^1.0.0"
+		"phpunit/phpunit": "^10.0 || ^11.0",
+		"phpstan/phpstan": "^1.0.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,10 +5,12 @@
 			<directory>tests</directory>
 		</testsuite>
 	</testsuites>
-	<filter>
-		<whitelist addUncoveredFilesFromWhitelist="true">
+	<source>
+		<include>
 			<directory suffix=".php">src</directory>
-			<exclude><directory suffix=".php">src/Generated</directory></exclude>
-		</whitelist>
-	</filter>
+		</include>
+		<exclude>
+			<directory suffix=".php">src/Generated</directory>
+		</exclude>
+	</source>
 </phpunit>


### PR DESCRIPTION
PHP 7.4, 8.0, and 8.1 are all end-of-life and block upgrading dependencies with known security vulnerabilities. This raises the minimum supported PHP version to 8.2.

## Changes

- **composer.json**
  - PHP constraint: \^8.0 || ^7.4\ → \^8.2\
  - PHPUnit: \^8.0 || ^9.0\ → \^10.0 || ^11.0\ (PHPUnit 8/9 do not support PHP 8.2+)
  - PHPStan: drop \^0.12.90\, require \^1.0.0\ only

- **\.github/workflows/pr-validation.yml\**
  - CI matrix updated to \['8.2', '8.3', '8.4', '8.5']\

- **\phpunit.xml\**
  - Replaced deprecated \<filter>/<whitelist>\ (PHPUnit 8/9) with \<source>/<include>\ (PHPUnit 10+)

Mirrors microsoftgraph/msgraph-beta-sdk-php#448
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-php/pull/1769)